### PR TITLE
[ADP-3149] Add `import` syntax to `Module`

### DIFF
--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -23,6 +23,7 @@ common language
   default-extensions:
     NoImplicitPrelude
   other-extensions:
+    NamedFieldPuns
     OverloadedStrings
 
 common opts-lib

--- a/lib/fine-types/src/Language/FineTypes/Module.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module.hs
@@ -1,13 +1,21 @@
+{-# LANGUAGE NamedFieldPuns #-}
 -- | A 'Module' is a collection of 'Typ' definitions.
 module Language.FineTypes.Module
-    ( Module (..)
+    ( ModuleName
+    , Module (..)
+    , Import (..)
+    , Imports
     , Declarations
+    , resolveImports
     , collectNotInScope
     , resolveVars
     ) where
 
 import Prelude
 
+import Control.Monad
+    ( forM
+    )
 import Data.Map
     ( Map
     )
@@ -27,20 +35,26 @@ import qualified Data.Set as Set
 {-----------------------------------------------------------------------------
     Module type
 ------------------------------------------------------------------------------}
+type ModuleName = String
 
 -- | A 'Module' is a collection of 'Typ' definitions and documentation.
 data Module = Module
-    { moduleName :: String
+    { moduleName :: ModuleName
+    , moduleImports :: Imports
     , moduleDeclarations :: Declarations
     }
     deriving (Eq, Show)
 
 type Declarations = Map TypName Typ
 
-{-----------------------------------------------------------------------------
-    Module functions
-------------------------------------------------------------------------------}
+type Imports = Map ModuleName Import
 
+newtype Import = ImportNames { getImportNames :: Set TypName }
+    deriving (Eq, Show)
+
+{-----------------------------------------------------------------------------
+    Name resolution
+------------------------------------------------------------------------------}
 -- | Resolve all variables in a 'Typ' that can be resolved
 -- using the given declarations.
 --
@@ -53,13 +67,35 @@ resolveVars declarations = everywhere resolve
         Just typ -> everywhere resolve typ
     resolve a = a
 
--- | Collect all 'Typ' names that have not been defined in the 'Module'.
-collectNotInScope :: Module -> Set TypName
-collectNotInScope Module{moduleDeclarations = declarations} =
-    rhs Set.\\ lhs
+-- | For a given 'Module', resolve @import@ by adding the declarations
+-- for the imported names.
+--
+-- Fails if an imported name cannot be found.
+resolveImports
+    :: Map ModuleName Module
+    -> Module
+    -> Maybe Declarations
+resolveImports modulesInScope m0 =
+    (moduleDeclarations m0 <>) . Map.fromList <$> resolve
   where
-    lhs = Map.keysSet declarations
-    rhs = mconcat . map collectVars $ Map.elems declarations
+    resolve = concat <$> forM (Map.toList $ moduleImports m0) resolveImport
+    resolveImport (moduleName, ImportNames names) = do
+        m1 <- Map.lookup moduleName modulesInScope
+        forM (Set.toList names) $ \name -> do
+            typ <- Map.lookup name (moduleDeclarations m1)
+            pure (name, typ)
+
+-- | Collect all 'Typ' names that have not been defined or imported
+-- in the 'Module'.
+collectNotInScope :: Module -> Set TypName
+collectNotInScope Module{moduleDeclarations,moduleImports} =
+    needed Set.\\ defined
+  where
+    defined = declaredNames <> importedNames
+    declaredNames = Map.keysSet moduleDeclarations
+    importedNames = mconcat (getImportNames <$> Map.elems moduleImports)
+
+    needed = mconcat . map collectVars $ Map.elems moduleDeclarations
 
 -- | Collect all 'Var' in a 'Typ'.
 collectVars :: Typ -> Set TypName

--- a/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
@@ -5,7 +5,13 @@ module Language.FineTypes.Module.Gen where
 
 import Prelude
 
-import Language.FineTypes.Module (Declarations, Module (..))
+import Language.FineTypes.Module
+    ( Declarations
+    , Module (..)
+    , ModuleName
+    , Import (..)
+    , Imports
+    )
 import Language.FineTypes.Typ (Typ, TypName)
 import Language.FineTypes.Typ.Gen
     ( Mode (Complete)
@@ -20,12 +26,23 @@ import Test.QuickCheck
     )
 
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 genModule :: Gen Module
 genModule = do
     moduleName <- genModuleName
+    moduleImports <- genImports
     moduleDeclarations <- genDeclarations
     pure Module{..}
+
+genImports :: Gen Imports
+genImports = Map.fromList <$> listOf genImport
+
+genImport :: Gen (ModuleName, Import)
+genImport = do
+    moduleName <- genModuleName
+    imports <- ImportNames . Set.fromList <$> listOf genTypName
+    pure (moduleName, imports)
 
 genDeclarations :: Gen Declarations
 genDeclarations = Map.fromList <$> listOf genDeclaration
@@ -46,6 +63,8 @@ shrinkModule :: Module -> [Module]
 shrinkModule m = do
     moduleDeclarations <- shrinkDeclarations (moduleDeclarations m)
     pure $ m{moduleDeclarations}
+
+-- TODO: Shrink import list
 
 shrinkDeclarations :: Declarations -> [Declarations]
 shrinkDeclarations xs = do

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -12,6 +12,9 @@ import Data.Void
 import Language.FineTypes.Module
     ( Declarations
     , Module (Module)
+    , ModuleName
+    , Import (..)
+    , Imports
     )
 import Language.FineTypes.Typ
     ( ConstructorName
@@ -39,6 +42,7 @@ import Text.Megaparsec
 
 import qualified Control.Monad.Combinators.Expr as Parser.Expr
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import qualified Text.Megaparsec.Char as Parser.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
@@ -74,7 +78,21 @@ module' =
         <$ symbol "module"
         <*> moduleName
         <* symbol "where"
+        <*> imports
         <*> declarations
+
+imports :: Parser Imports
+imports = mconcat <$> (import' `endBy` symbol ";")
+
+import' :: Parser Imports
+import' =
+    Map.singleton
+        <$ symbol "import"
+        <*> moduleName
+        <*> (toImport <$> importedNames)
+  where
+    importedNames = parens (typName `sepBy` symbol ",")
+    toImport = ImportNames . Set.fromList
 
 declarations :: Parser Declarations
 declarations = mconcat <$> (declaration `endBy` symbol ";")
@@ -168,7 +186,7 @@ space = L.space Parser.Char.space1 lineComment blockComment
 symbol :: String -> Parser String
 symbol = L.symbol space
 
-moduleName :: Parser String
+moduleName :: Parser ModuleName
 moduleName = typName
 
 typName :: Parser TypName


### PR DESCRIPTION
### Overview

This pull request adds `import` declaration à la Haskell to the FineTypes language, for example

```
import Crypto(VKey, Sig, ScriptHash);
```
### Changes

- [x] `import` can be represented, parsed and pretty-printed.
- [x] `collectNotInScope` considers imported names to be in scope.
- [x] `resolveImports` adds declarations corresponding the imported names.

### Comments

* This pull request only implements the syntax, but does not yet provide any link between modules and files in the filesystem; such functionality would be part of a `Package` concept.
* The utility function `resolveImports` provides a preliminary means for resolving imports from different modules for the purpose of experimentation and testing.