### PR TITLE
[ADP-3152] Export of FineTypes to Haskell

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ index-state:
 
 packages:
     lib/fine-types/
+    lib/fine-types-test/
 
 tests:
   True

--- a/lib/fine-types-test/LICENSE
+++ b/lib/fine-types-test/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2022–2023 Jonathan Knowles
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/fine-types-test/Setup.hs
+++ b/lib/fine-types-test/Setup.hs
@@ -1,0 +1,30 @@
+import Control.Monad
+import Distribution.Simple
+import Distribution.Simple.BuildPaths (autogenComponentModulesDir)
+import Distribution.Simple.LocalBuildInfo
+import System.Directory
+import System.FilePath
+import System.Process (callProcess)
+
+main :: IO ()
+main = defaultMainWithHooks hooks
+
+hooks :: UserHooks
+hooks = simpleUserHooks{postConf = \_ _ _ lbi -> generateSources lbi}
+
+generateSources :: LocalBuildInfo -> IO ()
+generateSources lbi =
+    forM_ (allComponentsInBuildOrder lbi) $ \clbi -> do
+        let dir = autogenComponentModulesDir lbi clbi
+            file = dir </> "Language/FineTypes/Test/UTxO.hs"
+        putStrLn $ concat ["*** Creating ", file, "."]
+        createDirectoryIfMissing True (takeDirectory file)
+        callProcess
+            "fine-types"
+            [ "convert"
+            , "haskell"
+            , "-i"
+            , "test/data/HaskellUTxO.fine"
+            , "-o"
+            , file
+            ]

--- a/lib/fine-types-test/fine-types-test.cabal
+++ b/lib/fine-types-test/fine-types-test.cabal
@@ -1,0 +1,82 @@
+cabal-version:      3.0
+build-type:         Custom
+name:               fine-types-test
+version:            0.1.0.0
+synopsis:           Tests of source code generated with fine-types
+description:
+  Tests of source code generated with fine-types.
+  .
+  This is a separate package because it uses the `fine-types` executable
+  to generate source code, and hence cannot be declared in the same
+  cabal package as `fine-types`.
+homepage:           https://github.com/cardano-foundation/fine-types
+license:            Apache-2.0
+license-file:       LICENSE
+author:             HAL, Cardano Foundation
+maintainer:         hal@cardanofoundation.org
+copyright:          2023 Cardano Foundation
+category:           Language
+
+extra-source-files:
+  test/data/**/*.fine
+
+custom-setup
+  setup-depends:
+    , base >=4.14.3.0
+    , Cabal >= 3.0 && < 4
+    , directory
+    , filepath
+    , process
+
+common language
+  default-language:
+    Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+  other-extensions:
+    NamedFieldPuns
+    OverloadedStrings
+
+common opts-lib
+  ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+common opts-exe
+  ghc-options: -threaded -rtsopts
+  ghc-options: -Wall -Wcompat -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates
+
+  if flag(release)
+    ghc-options: -O2 -Werror
+
+flag release
+  description: Enable optimization and `-Werror`
+  default:     False
+  manual:      True
+
+test-suite haskell
+  import:      language, opts-exe
+  type:        exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  build-tool-depends:
+    , hspec-discover:hspec-discover == 2.*
+    , fine-types:fine-types == 0.1.*
+  build-depends:
+    , base
+    , bytestring
+    , containers
+    , filepath
+    , fine-types
+    , hspec ^>= 2.11.0
+    , process
+    , QuickCheck
+    , text
+  main-is:
+    Spec.hs
+  other-modules:
+    Language.FineTypes.Export.Haskell.ValueSpec
+    Language.FineTypes.Test.UTxO
+  autogen-modules:
+    Language.FineTypes.Test.UTxO

--- a/lib/fine-types-test/test/Language/FineTypes/Export/Haskell/ValueSpec.hs
+++ b/lib/fine-types-test/test/Language/FineTypes/Export/Haskell/ValueSpec.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.FineTypes.Export.Haskell.ValueSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Language.FineTypes.Export.Haskell.Value.Runtime
+    ( ToValue (..)
+    )
+import Language.FineTypes.Test.UTxO
+    ( AssetID (..)
+    , AssetIDNonAda (..)
+    , Value
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldSatisfy
+    )
+
+import qualified Data.Map
+import qualified Language.FineTypes.Value as FineTypes
+
+{-----------------------------------------------------------------------------
+    Tests
+------------------------------------------------------------------------------}
+spec :: Spec
+spec = do
+    describe "exported Haskell module" $ do
+        it "compiles" True
+        it "maps to Value"
+            $ toValue example `shouldSatisfy` isFiniteMap
+
+isFiniteMap :: FineTypes.Value -> Bool
+isFiniteMap (FineTypes.Two (FineTypes.FiniteMap _)) = True
+isFiniteMap _ = False
+
+example :: Value
+example =
+    Data.Map.fromList
+        [ (Ada (), 1000)
+        , (Asset asset1, 42)
+        , (Asset asset2, 21)
+        ]
+
+asset1 :: AssetIDNonAda
+asset1 =
+    AssetIDNonAda
+        { policyId = "1337"
+        , assetName = "Leetcoin"
+        }
+
+asset2 :: AssetIDNonAda
+asset2 =
+    AssetIDNonAda
+        { policyId = "101"
+        , assetName = "Lolcoin"
+        }

--- a/lib/fine-types-test/test/Spec.hs
+++ b/lib/fine-types-test/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/lib/fine-types-test/test/data/HaskellUTxO.fine
+++ b/lib/fine-types-test/test/data/HaskellUTxO.fine
@@ -1,0 +1,64 @@
+module Language.FineTypes.Test.UTxO where
+
+{-----------------------------------------------------------------------------
+    UTxO type in the Babbage era
+    close to the specification
+------------------------------------------------------------------------------}
+ByteString = Bytes;
+ScriptHash = Bytes;
+
+Addr     = Bytes;
+Script   = Bytes;
+Datum    = Bytes;
+DataHash = Bytes;
+
+{-----------------------------------------------------------------------------
+    Value and Token Algebra
+    Mary spec, Figure 3, filtered, annotated
+------------------------------------------------------------------------------}
+AssetName = ByteString;
+PolicyID  = ScriptHash;
+AdaIDType = Unit;
+
+AssetID =
+  Σ{ ada   : AdaIDType
+  ,  asset : AssetIDNonAda
+  };
+
+AssetIDNonAda =
+  { policyId  : PolicyID
+  , assetName : AssetName
+  };
+
+Quantity  = ℤ;
+Value     = AssetID ↦0 Quantity;
+
+{-----------------------------------------------------------------------------
+    Transaction Body
+    Babbage spec, Figure 1, filtered, annotated
+------------------------------------------------------------------------------}
+TxOut =
+  { address   : Addr
+  , value     : Value
+  , datum     : DatumOrHash?
+  , scriptRef : Script?
+  };
+
+DatumOrHash =
+  Σ{ datum    : Datum
+  ,  dataHash : DataHash
+  };
+
+{-----------------------------------------------------------------------------
+    Transactions
+    Shelley spec, Figure 10, filtered, annotated
+------------------------------------------------------------------------------}
+TxId = Bytes;
+Ix = ℕ;
+
+TxIn =
+  { id    : TxId
+  , index : Ix
+  };
+
+UTxO = TxIn ↦ TxOut;

--- a/lib/fine-types/app/Options.hs
+++ b/lib/fine-types/app/Options.hs
@@ -5,7 +5,8 @@ module Options where
 import Prelude
 
 import Options.Applicative
-    ( command
+    ( Parser
+    , command
     , execParser
     , fullDesc
     , header
@@ -36,12 +37,13 @@ parseOptions =
   where
     options = Options <$> commands <*> optionLogFile
 
-    commands =
-        hsubparser
-            $ mconcat
-                [ command "convert"
-                    $ info (Convert <$> convertOptions) convertDescr
-                , command "check"
-                    $ info (Check <$> checkOptions) checkDescr
-                    -- other commands go here
-                ]
+commands :: Parser Commands
+commands =
+    hsubparser
+        $ mconcat
+            [ command "convert"
+                $ info (Convert <$> convertOptions) convertDescr
+            , command "check"
+                $ info (Check <$> checkOptions) checkDescr
+                -- other commands go here
+            ]

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -56,6 +56,8 @@ library
     , containers
     , deepseq >= 1.4.4
     , filepath >= 1.4.2
+    , haskell-src-exts ^>= 1.23.1
+    , haskell-src-exts-simple ^>= 1.23.0
     , insert-ordered-containers
     , megaparsec ^>= 9.2.1
     , openapi3
@@ -70,6 +72,8 @@ library
     , yaml
   exposed-modules:
     Language.FineTypes
+    Language.FineTypes.Export.Haskell.Language
+    Language.FineTypes.Export.Haskell.Typ
     Language.FineTypes.Export.OpenAPI.Schema
     Language.FineTypes.Export.OpenAPI.Value.FromJSON
     Language.FineTypes.Export.OpenAPI.Value.ToJSON

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -74,6 +74,8 @@ library
     Language.FineTypes
     Language.FineTypes.Export.Haskell.Language
     Language.FineTypes.Export.Haskell.Typ
+    Language.FineTypes.Export.Haskell.Value.Compiletime
+    Language.FineTypes.Export.Haskell.Value.Runtime
     Language.FineTypes.Export.OpenAPI.Schema
     Language.FineTypes.Export.OpenAPI.Value.FromJSON
     Language.FineTypes.Export.OpenAPI.Value.ToJSON

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Language.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Language.hs
@@ -6,6 +6,7 @@ module Language.FineTypes.Export.Haskell.Language
     , hsUnit
     , hsPair
     , hsImportQualified
+    , hsImportQualifiedAs
     ) where
 
 import Prelude
@@ -45,5 +46,17 @@ hsImportQualified name =
         , Hs.importSafe = False
         , Hs.importPkg = Nothing
         , Hs.importAs = Nothing
+        , Hs.importSpecs = Nothing
+        }
+
+hsImportQualifiedAs :: String -> String -> Hs.ImportDecl
+hsImportQualifiedAs name as =
+    Hs.ImportDecl
+        { Hs.importModule = Hs.ModuleName name
+        , Hs.importQualified = True
+        , Hs.importSrc = False
+        , Hs.importSafe = False
+        , Hs.importPkg = Nothing
+        , Hs.importAs = Just $ Hs.ModuleName as
         , Hs.importSpecs = Nothing
         }

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Language.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Language.hs
@@ -1,0 +1,49 @@
+-- | Utilities concerning the Haskell language.
+module Language.FineTypes.Export.Haskell.Language
+    ( raiseFirstLetter
+    , hsType
+    , hsList
+    , hsUnit
+    , hsPair
+    , hsImportQualified
+    ) where
+
+import Prelude
+
+import Language.FineTypes.Typ
+    ( TypName
+    )
+
+import qualified Data.Char
+import qualified Language.Haskell.Exts.Simple as Hs
+
+{-----------------------------------------------------------------------------
+    Haskell language utilities
+------------------------------------------------------------------------------}
+raiseFirstLetter :: String -> String
+raiseFirstLetter [] = []
+raiseFirstLetter (c : cs) = Data.Char.toUpper c : cs
+
+hsType :: TypName -> Hs.Type
+hsType = Hs.TyCon . Hs.UnQual . Hs.Ident
+
+hsList :: Hs.Type
+hsList = Hs.TyCon $ Hs.Special Hs.ListCon
+
+hsPair :: Hs.Type
+hsPair = Hs.TyCon $ Hs.Special $ Hs.TupleCon Hs.Boxed 2
+
+hsUnit :: Hs.Type
+hsUnit = Hs.TyCon $ Hs.Special Hs.UnitCon
+
+hsImportQualified :: String -> Hs.ImportDecl
+hsImportQualified name =
+    Hs.ImportDecl
+        { Hs.importModule = Hs.ModuleName name
+        , Hs.importQualified = True
+        , Hs.importSrc = False
+        , Hs.importSafe = False
+        , Hs.importPkg = Nothing
+        , Hs.importAs = Nothing
+        , Hs.importSpecs = Nothing
+        }

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Typ.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Typ.hs
@@ -1,0 +1,190 @@
+-- | Export 'Typ' definitions to Haskell type definitions.
+module Language.FineTypes.Export.Haskell.Typ
+    ( HsModule (..)
+    , prettyPrint
+    , haskellFromModule
+    ) where
+
+import Prelude
+
+import Language.FineTypes.Export.Haskell.Language
+    ( hsImportQualified
+    , hsList
+    , hsPair
+    , hsType
+    , hsUnit
+    , raiseFirstLetter
+    )
+import Language.FineTypes.Module
+    ( Module (..)
+    )
+import Language.FineTypes.Typ
+    ( ConstructorName
+    , FieldName
+    , OpOne (..)
+    , OpTwo (..)
+    , Typ (..)
+    , TypConst (..)
+    , TypName
+    )
+
+import qualified Data.Map as Map
+import qualified Language.Haskell.Exts.Simple as Hs
+
+{-----------------------------------------------------------------------------
+    Haskell
+------------------------------------------------------------------------------}
+newtype HsModule = HsModule {getHsModule :: Hs.Module}
+
+prettyPrint :: HsModule -> String
+prettyPrint = Hs.prettyPrint . getHsModule
+
+haskellFromModule :: Module -> HsModule
+haskellFromModule m =
+    HsModule
+        $ Hs.Module (Just moduleHead) modulePragmas imports declarations
+  where
+    moduleHead =
+        Hs.ModuleHead (Hs.ModuleName $ moduleName m) Nothing Nothing
+    modulePragmas =
+        optionsGHC <> languageExtensions
+    -- TODO: Filter set of imported modules in order to avoid switching
+    -- off the warning -Wno-unused-imports.
+    optionsGHC =
+        [Hs.OptionsPragma (Just Hs.GHC) "-Wno-unused-imports"]
+    languageExtensions =
+        map
+            (Hs.LanguagePragma . (: []) . Hs.Ident)
+            [ "DeriveGeneric"
+            , "DerivingStrategies" -- see Note [Deriving]
+            , "DuplicateRecordFields"
+            , "NoImplicitPrelude"
+            ]
+    imports =
+        map
+            hsImportQualified
+            [ "Prelude"
+            , "Data.ByteString"
+            , "Data.Map"
+            , "Data.Set"
+            , "Data.Text"
+            , "GHC.Generics"
+            , "Numeric.Natural"
+            ]
+    declarations =
+        [ declarationFromTyp name typ
+        | (name, typ) <- Map.toList (moduleDeclarations m)
+        ]
+
+{-----------------------------------------------------------------------------
+    Convert Typ to Haskell declaration
+------------------------------------------------------------------------------}
+declarationFromTyp :: TypName -> Typ -> Hs.Decl
+declarationFromTyp name typ = case typ of
+    ProductN fields ->
+        Hs.DataDecl
+            Hs.DataType
+            Nothing
+            declaredName
+            (declareProduct name fields)
+            derivingEqOrdGeneric
+    SumN constructors ->
+        Hs.DataDecl
+            Hs.DataType
+            Nothing
+            declaredName
+            (declareSum name constructors)
+            derivingEqOrdGeneric
+    _ ->
+        Hs.TypeDecl declaredName (typeFromTyp typ)
+  where
+    declaredName = Hs.DHead $ Hs.Ident name
+
+{- Note [Deriving]
+
+haskell-src-exts version 1.23.1 is not able to represent
+the Haskell98 deriving clause (`deriving (Eq,Ord,Generic)`).
+Instead, the generated code needs the `DerivingStrategies` extension.
+
+-}
+derivingEqOrdGeneric :: [Hs.Deriving]
+derivingEqOrdGeneric =
+    map
+        derivingClass
+        [ "Prelude.Eq"
+        , "Prelude.Ord"
+        , "Prelude.Show"
+        , "GHC.Generics.Generic"
+        ]
+  where
+    derivingClass c =
+        Hs.Deriving
+            Nothing
+            [Hs.IRule Nothing Nothing (instanceHead c)]
+    instanceHead = Hs.IHCon . Hs.UnQual . Hs.Ident
+
+declareProduct
+    :: TypName
+    -> [(FieldName, Typ)]
+    -> [Hs.QualConDecl]
+declareProduct name fields =
+    [ Hs.QualConDecl Nothing Nothing
+        $ Hs.RecDecl
+            (Hs.Ident name)
+            [Hs.FieldDecl [Hs.Ident n] (typeFromTyp t) | (n, t) <- fields]
+    ]
+
+-- | Declare a Haskell type with constructors, corresponding to
+-- a disjoint sum of types.
+--
+-- TODO: What about enumerations, i.e. when the arguments are 'Unit'?
+declareSum
+    :: TypName
+    -> [(ConstructorName, Typ)]
+    -> [Hs.QualConDecl]
+declareSum _ constructors =
+    [ Hs.QualConDecl Nothing Nothing
+        $ Hs.ConDecl (Hs.Ident (raiseFirstLetter cons)) arguments
+    | (cons, typ) <- constructors
+    , let arguments = [typeFromTyp typ]
+    ]
+
+typeFromTyp :: Typ -> Hs.Type
+typeFromTyp = go
+  where
+    go Abstract = error "Abstract is not supported by Haskell"
+    go (Var name) = hsType name
+    go (Zero c) = case c of
+        Bool -> hsType "Prelude.Bool"
+        Bytes -> hsType "Data.ByteString.ByteString"
+        Integer -> hsType "Prelude.Integer"
+        Natural -> hsType "Numeric.Natural.Natural"
+        Rational -> hsType "Prelude.Rational"
+        Text -> hsType "Data.Text.Text"
+        Unit -> hsUnit
+    go (One fun a) = fun1 `Hs.TyApp` go a
+      where
+        fun1 = case fun of
+            Option -> hsType "Prelude.Maybe"
+            Sequence -> hsList
+            PowerSet -> hsType "Data.Set.Set"
+    go (Two fun a b) = (fun2 `Hs.TyApp` go a) `Hs.TyApp` go b
+      where
+        fun2 = case fun of
+            Sum2 -> hsType "Prelude.Either"
+            Product2 -> hsPair
+            PartialFunction -> hsType "Data.Map.Map"
+            -- FIXME: FiniteSupport is bogus, we need to
+            -- associate a selected few types with default values.
+            -- Use Jonathan's 'monoidmap' package?
+            FiniteSupport -> hsType "Data.Map.Map"
+    go (ProductN _) =
+        error "Nested Product is not supported by Haskell"
+    go (SumN _) =
+        error "Nested Sum is not supported by Haskell"
+    go (Constrained typ _) =
+        -- FIXME: Emit a warning.
+        -- TODO: Add Liquid Haskell support for top-level definitions? 😲
+        -- Currently no good representation for comments / Liquid Haskell
+        -- in haskell-src-exts, though.
+        go typ

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Value/Compiletime.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Value/Compiletime.hs
@@ -1,0 +1,93 @@
+-- | Export values of Haskell types to 'Value', generated at compile time.
+module Language.FineTypes.Export.Haskell.Value.Compiletime
+    ( declareInstanceToValue
+    , declareToValueFunProduct
+    , declareToValueFunSum
+    ) where
+
+import Prelude
+
+import Language.FineTypes.Export.Haskell.Language
+    ( hsType
+    , raiseFirstLetter
+    )
+import Language.FineTypes.Typ
+    ( ConstructorName
+    , FieldName
+    , Typ
+    , TypName
+    )
+
+import qualified Language.Haskell.Exts.Simple as Hs
+
+{-----------------------------------------------------------------------------
+    Compile time definitions
+------------------------------------------------------------------------------}
+
+-- | Declare an @instance ToValue@ for a record type.
+declareInstanceToValue
+    :: TypName -> Hs.Decl -> Hs.Decl
+declareInstanceToValue name toValueDeclaration =
+    Hs.InstDecl Nothing instanceRule (Just instanceDecls)
+  where
+    instanceRule = Hs.IRule Nothing Nothing instanceHead
+    instanceHead = Hs.IHApp (Hs.IHCon className) (hsType name)
+    className = runtime "ToValue"
+    instanceDecls = [Hs.InsDecl toValueDeclaration]
+
+-- | Declare the funcion `toValue` for a record type.
+declareToValueFunProduct
+    :: TypName
+    -> [(FieldName, Typ)]
+    -> Hs.Decl
+declareToValueFunProduct constructor fields =
+    Hs.FunBind
+        [Hs.Match (Hs.Ident "toValue") [pat] rhs Nothing]
+  where
+    pat =
+        Hs.PApp
+            (Hs.UnQual $ Hs.Ident constructor)
+            [ Hs.PVar (Hs.Ident $ field <> "_pat")
+            | (field, _) <- fields
+            ]
+    rhs = Hs.UnGuardedRhs $ productV `Hs.App` Hs.List arguments
+    arguments =
+        [ Hs.Var (runtime "toValue") `Hs.App` var (field <> "_pat")
+        | (field, _) <- fields
+        ]
+    productV = Hs.Con (runtime "Product")
+
+-- | Declare the funcion `toValue` for a sum type.
+declareToValueFunSum
+    :: TypName
+    -> [(ConstructorName, Typ)]
+    -> Hs.Decl
+declareToValueFunSum _ constructors =
+    Hs.FunBind
+        [ Hs.Match
+            (Hs.Ident "toValue")
+            [pat constructor]
+            (rhs ix)
+            Nothing
+        | (ix, (constructor, _)) <- zip [0 ..] constructors
+        ]
+  where
+    pat constructor =
+        Hs.PApp
+            (Hs.UnQual $ Hs.Ident $ raiseFirstLetter constructor)
+            [Hs.PVar (Hs.Ident "x")]
+    rhs ix =
+        Hs.UnGuardedRhs
+            $ (sumV `Hs.App` int ix)
+                `Hs.App` (Hs.Var (runtime "toValue") `Hs.App` var "x")
+    int ix = Hs.Lit $ Hs.Int ix
+    sumV = Hs.Con (runtime "Sum")
+
+{-----------------------------------------------------------------------------
+    Expression utilities
+------------------------------------------------------------------------------}
+runtime :: String -> Hs.QName
+runtime = Hs.Qual (Hs.ModuleName "FineTypes.Value") . Hs.Ident
+
+var :: String -> Hs.Exp
+var = Hs.Var . Hs.UnQual . Hs.Ident

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Value/Runtime.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Value/Runtime.hs
@@ -1,0 +1,64 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use bimap" #-}
+
+-- | Export values of Haskell types to 'Value'.
+module Language.FineTypes.Export.Haskell.Value.Runtime
+    ( ToValue (..)
+    , V.Value (..)
+    ) where
+
+import Prelude ((.))
+
+import qualified Language.FineTypes.Value as V
+
+import qualified Data.ByteString
+import qualified Data.Map
+import qualified Data.Set
+import qualified Data.Text
+import qualified Numeric.Natural
+import qualified Prelude
+
+{-----------------------------------------------------------------------------
+    Runtime definitions
+------------------------------------------------------------------------------}
+
+-- | Class of types that can be converted to 'Value'.
+--
+-- Note: The 'Ord' constraint is necessary to deal with 'Set'.
+class Prelude.Ord a => ToValue a where
+    toValue :: a -> V.Value
+
+z :: V.ZeroF -> V.Value
+z = V.Zero
+
+instance ToValue Prelude.Bool where toValue = z . V.Bool
+instance ToValue Data.ByteString.ByteString where toValue = z . V.Bytes
+instance ToValue Prelude.Integer where toValue = z . V.Integer
+instance ToValue Numeric.Natural.Natural where toValue = z . V.Natural
+instance ToValue Data.Text.Text where toValue = z . V.Text
+instance ToValue () where toValue _ = z V.Unit
+
+instance ToValue a => ToValue (Prelude.Maybe a) where
+    toValue = V.One . V.Option . Prelude.fmap toValue
+
+instance ToValue a => ToValue [a] where
+    toValue = V.One . V.Sequence . Prelude.fmap toValue
+
+instance ToValue a => ToValue (Data.Set.Set a) where
+    toValue = V.One . V.PowerSet . Data.Set.map toValue
+
+instance (ToValue a, ToValue b) => ToValue (Prelude.Either a b) where
+    toValue (Prelude.Left a) = V.Sum 0 (toValue a)
+    toValue (Prelude.Right b) = V.Sum 1 (toValue b)
+
+instance (ToValue a, ToValue b) => ToValue (a, b) where
+    toValue (a, b) = V.Product [toValue a, toValue b]
+
+instance (ToValue a, ToValue b) => ToValue (Data.Map.Map a b) where
+    toValue =
+        V.Two
+            . V.FiniteMap
+            . Data.Map.fromList
+            . Prelude.map (\(k, v) -> (toValue k, toValue v))
+            . Data.Map.toList

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -358,7 +358,11 @@ symbol :: String -> Parser String
 symbol = L.symbol space
 
 moduleName :: Parser ModuleName
-moduleName = typName
+moduleName =
+    L.lexeme space
+        $ (:)
+            <$> C.upperChar
+            <*> many (C.alphaNumChar <|> satisfy (`elem` "."))
 
 typName :: Parser TypName
 typName =


### PR DESCRIPTION
This pull requests implements the export of FineTypes `Typ` to Haskell types.

- [x] The command `fine-types convert` is able to export a FineTypes module to a Haskell module.
- [x] The types in the exported Haskell module are instances of a class `ToValue a` with member function `toValue :: a -> Value`.
- [x] A unit test covers the functionality by autogenerating a Haskell module from the file and using it in the `fine-types-test` package.