### PR TITLE
Make formatting pipeline fail if something had to be formatted

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
   - label: 'Check format'
     depends_on: linux-nix
     command: |
-      ${nix} --command bash -c "echo +++ format; just format"
+      ${nix} --command bash -c "echo +++ format; just format; git diff --exit-code"
     agents:
       system: ${linux}
     env:


### PR DESCRIPTION
This pull request changes the Buildkite pipeline to fail if the formatting step changed any files.