### PR TITLE
[ADP-3156] Parse documentation in FineType modules

### DIFF
--- a/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
@@ -39,6 +39,7 @@ genModule = do
     moduleName <- genModuleName
     moduleImports <- genImports
     moduleDeclarations <- logScale 1.1 genDeclarations
+    let moduleDocumentation = mempty
     pure Module{..}
 
 genImports :: Gen Imports

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -6,16 +6,22 @@ module Language.FineTypes.Parser
 
 import Prelude
 
+import Control.Monad (void)
 import Data.Char (isSpace)
+import Data.Map (Map)
 import Data.Void
     ( Void
     )
 import Language.FineTypes.Module
     ( Declarations
+    , DocString
+    , Documentation
     , Import (..)
     , Imports
     , Module (Module)
     , ModuleName
+    , Place (..)
+    , document
     )
 import Language.FineTypes.Typ
     ( Constraint
@@ -31,14 +37,19 @@ import Language.FineTypes.Typ
 import Text.Megaparsec
     ( ParseErrorBundle
     , Parsec
+    , anySingle
     , between
     , endBy
     , many
+    , manyTill
+    , notFollowedBy
     , parse
     , parseMaybe
     , satisfy
     , sepBy
+    , skipMany
     , some
+    , takeWhileP
     , try
     , (<?>)
     , (<|>)
@@ -47,6 +58,7 @@ import Text.Megaparsec
 import qualified Control.Monad.Combinators.Expr as Parser.Expr
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Language.FineTypes.Module as Module
 import qualified Text.Megaparsec.Char as C
 import qualified Text.Megaparsec.Char.Lexer as L
 
@@ -77,14 +89,19 @@ moduleFull :: Parser Module
 moduleFull = space *> module'
 
 module' :: Parser Module
-module' =
-    Module
-        <$ symbol "module"
-        <*> moduleName
-        <* symbol "where"
-        <*> imports
-        <*> declarations
-        <*> pure mempty
+module' = do
+    _ <- symbol "module"
+    n <- moduleName
+    _ <- symbol "where"
+    i <- imports
+    (decls, docs) <- declarations
+    pure
+        Module
+            { Module.moduleName = n
+            , Module.moduleImports = i
+            , Module.moduleDeclarations = decls
+            , Module.moduleDocumentation = docs
+            }
 
 imports :: Parser Imports
 imports = mconcat <$> (import' `endBy` symbol ";")
@@ -99,15 +116,47 @@ import' =
     importedNames = parens (typName `sepBy` symbol ",")
     toImport = ImportNames . Set.fromList
 
-declarations :: Parser Declarations
-declarations = mconcat <$> (declaration `endBy` symbol ";")
+type DocumentedDeclarations = (Declarations, Documentation)
 
--- | Parse a single declaration
-declaration :: Parser Declarations
-declaration = Map.singleton <$> typName <* symbol "=" <*> rhs
+declarations :: Parser DocumentedDeclarations
+declarations = mconcat <$> many declaration
+
+-- | Parse a single declaration, with documentation comments.
+declaration :: Parser DocumentedDeclarations
+declaration =
+    mkDocumentedDeclaration
+        <$> documentationPre
+        <*> typName
+        <* symbol "="
+        <*> rhs
+        <* symbol ";"
+        <*> documentationPost
   where
-    rhs :: Parser Typ
-    rhs = try abstract <|> try productN <|> try sumN <|> expr
+    rhs :: Parser DocumentedTyp
+    rhs =
+        try (notDocumented <$> abstract)
+            <|> try productN
+            <|> try sumN
+            <|> (notDocumented <$> expr)
+
+mkDocumentedDeclaration
+    :: Map Place DocString
+    -> TypName
+    -> DocumentedTyp
+    -> Map Place DocString
+    -> DocumentedDeclarations
+mkDocumentedDeclaration doc1 name (DocumentedTyp typ fs cs) doc2 =
+    (decl, docs)
+  where
+    decl = Map.singleton name typ
+    docs =
+        mconcat
+            [ document (Module.Typ name) d
+            | d <- [doc1, doc2]
+            , not (Map.null d)
+            ]
+            <> mconcat [document (Module.Field name f) d | (f, d) <- fs]
+            <> mconcat [document (Module.Constructor name c) d | (c, d) <- cs]
 
 constrained :: Parser Typ
 constrained = braces $ do
@@ -120,17 +169,64 @@ constrained = braces $ do
 abstract :: Parser Typ
 abstract = Abstract <$ symbol "_"
 
-productN :: Parser Typ
-productN = ProductN <$> braces (field `sepBy` symbol ",")
+data DocumentedTyp
+    = DocumentedTyp
+        Typ
+        [(FieldName, Map Place DocString)]
+        [(ConstructorName, Map Place DocString)]
 
-field :: Parser (FieldName, Typ)
-field = (,) <$> fieldName <* symbol ":" <*> expr
+notDocumented :: Typ -> DocumentedTyp
+notDocumented typ = DocumentedTyp typ [] []
 
-sumN :: Parser Typ
-sumN = SumN <$> sumBraces (constructor `sepBy` symbol ",")
+mkProductN :: [DocumentedField] -> DocumentedTyp
+mkProductN fields = DocumentedTyp typ doc []
+  where
+    typ = ProductN [(name, t) | DocumentedField name t _ <- fields]
+    doc = [(name, d) | DocumentedField name _ d <- fields, not (Map.null d)]
 
-constructor :: Parser (FieldName, Typ)
-constructor = (,) <$> constructorName <* symbol ":" <*> expr
+-- | Parse a disjoint product with field names.
+productN :: Parser DocumentedTyp
+productN = mkProductN <$> braces (field `sepBy` symbol ",")
+
+data DocumentedField
+    = DocumentedField FieldName Typ (Map Place DocString)
+
+field :: Parser DocumentedField
+field =
+    mkDocumentedField
+        <$> documentationPre
+        <*> fieldName
+        <* symbol ":"
+        <*> expr
+        <*> documentationPost
+  where
+    mkDocumentedField a b c d =
+        DocumentedField b c (a <> d)
+
+mkSumN :: [DocumentedConstructor] -> DocumentedTyp
+mkSumN cs = DocumentedTyp typ [] doc
+  where
+    typ = SumN [(name, t) | DocumentedConstructor name t _ <- cs]
+    doc = [(name, d) | DocumentedConstructor name _ d <- cs, not (Map.null d)]
+
+-- | Parse a disjoint sum with constructor names.
+sumN :: Parser DocumentedTyp
+sumN = mkSumN <$> sumBraces (constructor `sepBy` symbol ",")
+
+data DocumentedConstructor
+    = DocumentedConstructor ConstructorName Typ (Map Place DocString)
+
+constructor :: Parser DocumentedConstructor
+constructor =
+    mkDocumentedConstructor
+        <$> documentationPre
+        <*> constructorName
+        <* symbol ":"
+        <*> expr
+        <*> documentationPost
+  where
+    mkDocumentedConstructor a b c d =
+        DocumentedConstructor b c (a <> d)
 
 -- | Parse an expression.
 expr :: Parser Typ
@@ -202,14 +298,49 @@ prefix
 prefix name f = Parser.Expr.Prefix (f <$ symbol name)
 postfix name f = Parser.Expr.Postfix (f <$ symbol name)
 
+documentationPre :: Parser (Map Place DocString)
+documentationPre =
+    try (Map.singleton BeforeMultiline <$> blockDocumentationPre)
+        <|> (Map.singleton Before <$> lineDocumentationPre)
+        <|> mempty
+
+documentationPost :: Parser (Map Place DocString)
+documentationPost =
+    (Map.singleton After <$> lineDocumentationPost) <|> mempty
+
 {-----------------------------------------------------------------------------
     Lexer
 ------------------------------------------------------------------------------}
+
+-- | Parse the rest of a line, without the newline character.
+line :: Parser String
+line = takeWhileP (Just "character") (/= '\n')
+
 lineComment :: Parser ()
-lineComment = L.skipLineComment "--"
+lineComment =
+    try start <* line
+  where
+    start = C.string "--" *> notFollowedBy (satisfy (`elem` "^|"))
+
+lineDocumentationPre :: Parser DocString
+lineDocumentationPre =
+    C.string "--|" *> skipMany C.space1 *> line <* space
+
+lineDocumentationPost :: Parser DocString
+lineDocumentationPost =
+    C.string "--^" *> skipMany C.space1 *> line <* space
 
 blockComment :: Parser ()
-blockComment = L.skipBlockComment "{-" "-}"
+blockComment =
+    void (try start *> manyTill anySingle (C.string "-}"))
+  where
+    start = C.string "{-" *> notFollowedBy (C.char '|')
+
+blockDocumentationPre :: Parser DocString
+blockDocumentationPre =
+    start *> manyTill anySingle (C.string "-}") <* space
+  where
+    start = C.string "{-|" *> skipMany C.space1
 
 space :: Parser ()
 space = L.space C.space1 lineComment blockComment

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -84,6 +84,7 @@ module' =
         <* symbol "where"
         <*> imports
         <*> declarations
+        <*> pure mempty
 
 imports :: Parser Imports
 imports = mconcat <$> (import' `endBy` symbol ";")

--- a/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
@@ -95,7 +95,7 @@ specParsesDocumentation =
 specPrettyOnFile :: FilePath -> Spec
 specPrettyOnFile fp = do
     it ("holds for file" <> fp) $ do
-        file <- readFile "test/data/ParseTestBabbage.fine"
+        file <- readFile fp
         Just m <- pure $ parseFineTypes file
         let output = prettyPrintModule m
             m' = parseFineTypes output

--- a/lib/fine-types/test/data/DocumentationTest.fine
+++ b/lib/fine-types/test/data/DocumentationTest.fine
@@ -1,0 +1,32 @@
+module DocumentationTest where
+
+{-----------------------------------------------------------------------------
+    This module has different documentation texts,
+    for testing the parser.
+------------------------------------------------------------------------------}
+--| Documentation text before a type.
+A1 = ℕ; --^ Documentation text after a type.
+
+{-| Multiline documentation text before a type.
+-}
+A2 = ℤ;
+
+B =
+  { --| Documentation text before a field name.
+    b1 : A1 + A2 --^ Documentation text after a field name.
+  , --| Documentation text before a field name.
+    b2 : (A1 × A2)* --^ Documentation text after a field name.
+  , {-| Multiline documentation text before a field name.
+    -}
+    b3 : ℤ? --^ Documentation text after a field name.
+  };
+
+C =
+  Σ{ --| Documentation text before a constructor name.
+    c1 : A1 + A2 --^ Documentation text after a constructor name.
+  , --| Documentation text before a constructor name.
+    c2 : (A1 × A2)* --^ Documentation text after a constructor name.
+  , {-| Multiline documentation text before a constructor name.
+    -}
+    c3 : ℤ? --^ Documentation text after a constructor name.
+  };


### PR DESCRIPTION
This pull request parses inline documentation in FineType modules, similar to Haddock comments.

### Design notes

* In the `Module` record, the inline documentation is stored in a separate field `moduleDocumentation`, rather than put inside the `Typ` definition. This makes parsing and pretty-printing a little more awkward, because the representation of the documentation no longer follows the syntax tree, but I believe that this representation is more convenient for use cases which want to ignore the documentation, such as `Typ`-checking `Value`.
* The inline documentation syntax changes the syntax for comments:
   * `--^` and `--|` ,`{-|` are no longer regular comments, parsing should fail.
   * `--^` is accepted after a type definition, field or constructor name. Here, the documentation text goes to the end of the line, no newlines.
   * `--|` is accepted before a type definition, field or constructor name. (no newlines)
   * `{-| ... -}` is accepted before a type definition, field or constructor name; this documentation text may contain newlines.
   * Example: `UTxO = TxIn ↦ TxOut;  --^ unspent tx outputs`

### Comments

* With this syntax in place, we can get parseable documentation of the ledger specification(s). 😲 
* The choice of syntax (special treatment and placement of `--|` and `--^`) is informed by the fact that Haddock-style comments are actually quite tricky to parse, see [GHC's haddock source code][haddock]. The syntax above fits well into the regular syntax tree while ensuring that the documentation text can be treated as regular comments if desired.

  [haddock]: https://downloads.haskell.org/ghc/9.0.1/docs/html/libraries/ghc-9.0.1/src/GHC-Parser-PostProcess-Haddock.html#addHaddockToModule

### Issue number

ADP-3156