### PR TITLE
[ADP-3159] use modified GenT with hoist support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,5 +7,11 @@ index-state:
 packages:
     lib/fine-types/
 
+source-repository-package
+    type: git
+    location: https://github.com/paolino/QuickCheck-GenT.git
+    tag: c11a7a2ef4f83a98b0fcc421c7f7b06f9c5c1a11
+    --sha256: sha256-o1lHt9XqvkZOfrWoKLRHB0m0fNvxwj9s2pGwvPpfT68=
+
 tests:
   True

--- a/flake.lock
+++ b/flake.lock
@@ -169,6 +169,22 @@
         "type": "github"
       }
     },
+    "gen-t": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1694419842,
+        "narHash": "sha256-o1lHt9XqvkZOfrWoKLRHB0m0fNvxwj9s2pGwvPpfT68=",
+        "owner": "paolino",
+        "repo": "QuickCheck-GenT",
+        "rev": "c11a7a2ef4f83a98b0fcc421c7f7b06f9c5c1a11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paolino",
+        "repo": "QuickCheck-GenT",
+        "type": "github"
+      }
+    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -593,6 +609,7 @@
         "CHaP": "CHaP",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "gen-t": "gen-t",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
     # non-flake nix compatibility
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
+    gen-t.url = "github:paolino/QuickCheck-GenT";
+    gen-t.flake = false;
   };
 
   outputs = inputs:
@@ -24,7 +26,9 @@
         # not supported on ci.iog.io right now
         #"aarch64-linux"
         "aarch64-darwin"
-       ]; in
+       ];
+
+       in
     inputs.flake-utils.lib.eachSystem supportedSystems (system:
       let
         # setup our nixpkgs with the haskell.nix overlays, and the iohk-nix

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ format:
     fourmolu -i lib
 
 lint:
-    hlint lib 
+    hlint lib
 
 build0:
     cabal build -v0 -O0 -j fine-types
@@ -25,12 +25,11 @@ test:
 test-seed:
     @cabal test -v0 -O0 -j unit \
         --test-show-details=direct \
-        --test-options="--format=checks --color" \
+        --test-options="--format=checks --no-color" \
         --test-options="--seed {{seed}}"
 
-repl: 
+repl:
     cabal repl -v0 -O0 -j fine-types
 
 prepare: format lint build0 test
 ghci:
-    

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -57,6 +57,7 @@ library
     , deepseq >= 1.4.4
     , insert-ordered-containers
     , megaparsec ^>= 9.2.1
+    , mmorph
     , mtl
     , openapi3
     , parser-combinators
@@ -64,6 +65,7 @@ library
     , prettyprinter
     , QuickCheck
     , QuickCheck-GenT
+    , random
     , text
     , transformers
     , tree-diff

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -57,11 +57,13 @@ library
     , deepseq >= 1.4.4
     , insert-ordered-containers
     , megaparsec ^>= 9.2.1
+    , mtl
     , openapi3
     , parser-combinators
     , pretty-simple
     , prettyprinter
     , QuickCheck
+    , QuickCheck-GenT
     , text
     , transformers
     , tree-diff

--- a/lib/fine-types/src/Language/FineTypes/Module.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module.hs
@@ -12,6 +12,7 @@ module Language.FineTypes.Module
       -- * Documentation texts
     , Identifier (..)
     , DocString
+    , IdentifierDocumentation
     , Documentation (..)
     , Place (..)
     , document
@@ -88,8 +89,12 @@ instance ToExpr Identifier
 
 type DocString = String
 
+-- | Documentation texts associated to one identifier.
+type IdentifierDocumentation = Map Place DocString
+
 -- | Documentation texts associated to 'Identifiers'.
-newtype Documentation = Documentation {getDocumentation :: Map Identifier (Map Place DocString)}
+newtype Documentation = Documentation
+    {getDocumentation :: Map Identifier IdentifierDocumentation}
     deriving (Eq, Show, Generic)
 
 instance ToExpr Documentation

--- a/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Language.FineTypes.Module.Gen where
 
 import Prelude
 
+import Control.Monad.Morph (MFunctor (..))
+import Control.Monad.Reader (runReaderT)
 import Control.Monad.State (MonadState (..), StateT, evalStateT, lift, modify)
 import Control.Monad.Writer (Writer, runWriter)
 import Data.Foldable (fold)
@@ -87,10 +89,8 @@ genDeclaration = do
     typName <- liftGen genTypName `suchThat` (`Set.notMember` used)
     lift $ modify $ Set.insert typName
     typ <-
-        let
-            ?typname = typName
-         in
-            genTyp (const False) WithConstraints Complete 6
+        hoist (`runReaderT` typName)
+            $ genTyp (const False) WithConstraints Complete 6
     genDocumentation (Typ typName)
     pure (typName, typ)
 

--- a/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Module/Gen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -5,8 +7,15 @@ module Language.FineTypes.Module.Gen where
 
 import Prelude
 
+import Control.Monad.State (MonadState (..), StateT, evalStateT, lift, modify)
+import Control.Monad.Writer (Writer, runWriter)
+import Data.Foldable (fold)
+import Data.Functor.Identity (Identity (..))
+import Data.Set (Set)
 import Language.FineTypes.Module
     ( Declarations
+    , Documentation (..)
+    , Identifier (..)
     , Import (..)
     , Imports
     , Module (..)
@@ -15,16 +24,19 @@ import Language.FineTypes.Module
 import Language.FineTypes.Typ
     ( Typ (..)
     , TypName
+    , everything
     )
 import Language.FineTypes.Typ.Gen
     ( Mode (Complete)
     , WithConstraints (..)
     , capitalise
+    , genDocumentation
     , genName
     , genTyp
     , logScale
     , shrinkTyp
     )
+import QuickCheck.GenT (GenT, MonadGen (liftGen), runGenT, suchThat)
 import Test.QuickCheck
     ( Gen
     , listOf
@@ -33,17 +45,20 @@ import Test.QuickCheck
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified QuickCheck.GenT as GT
+
+logScaleGen :: Double -> Gen a -> Gen a
+logScaleGen x f = deGenT $ logScale x $ liftGen f
 
 genModule :: Gen Module
 genModule = do
     moduleName <- genModuleName
     moduleImports <- genImports
-    moduleDeclarations <- logScale 1.1 genDeclarations
-    let moduleDocumentation = mempty
+    (moduleDeclarations, moduleDocumentation) <- logScaleGen 1.1 genDeclarations
     pure Module{..}
 
 genImports :: Gen Imports
-genImports = Map.fromList <$> logScale 1.5 (listOf genImport)
+genImports = Map.fromList <$> logScaleGen 1.5 (listOf genImport)
 
 genImport :: Gen (ModuleName, Import)
 genImport = do
@@ -51,25 +66,76 @@ genImport = do
     imports <- ImportNames . Set.fromList <$> listOf genTypName
     pure (moduleName, imports)
 
-genDeclarations :: Gen Declarations
-genDeclarations = Map.fromList <$> listOf genDeclaration
+genDeclarations :: Gen (Declarations, Documentation)
+genDeclarations = do
+    (ds, d) <-
+        fmap (runWriter . flip evalStateT mempty)
+            $ runGenT
+            $ GT.listOf genDeclaration
+    pure (Map.fromList ds, d)
 
-genDeclaration :: Gen (TypName, Typ)
+noName :: TypName
+noName = error "no typ name"
+
+type GenerateUniqueWithDocs =
+    GenT
+        (StateT (Set TypName) (Writer Documentation))
+
+genDeclaration :: GenerateUniqueWithDocs (TypName, Typ)
 genDeclaration = do
-    typName <- genTypName
-    typ <- genTyp WithConstraints Complete 6
+    used <- lift get
+    typName <- liftGen genTypName `suchThat` (`Set.notMember` used)
+    lift $ modify $ Set.insert typName
+    typ <-
+        let
+            ?typname = typName
+         in
+            genTyp (const False) WithConstraints Complete 6
+    genDocumentation (Typ typName)
     pure (typName, typ)
 
 genTypName :: Gen TypName
-genTypName = capitalise <$> genName
+genTypName = capitalise <$> deGenT genName
 
 genModuleName :: Gen String
-genModuleName = capitalise <$> genName
+genModuleName = capitalise <$> deGenT genName
+
+deGenT :: GenT Identity a -> Gen a
+deGenT = fmap runIdentity . runGenT
 
 shrinkModule :: Module -> [Module]
 shrinkModule m = do
-    moduleDeclarations <- shrinkDeclarations (moduleDeclarations m)
-    pure $ m{moduleDeclarations}
+    moduleDeclarations <-
+        shrinkDeclarations
+            $ moduleDeclarations m
+    moduleDocumentation <-
+        pure
+            $ restrict moduleDeclarations
+            $ moduleDocumentation m
+    pure $ m{moduleDeclarations, moduleDocumentation}
+
+restrict :: Declarations -> Documentation -> Documentation
+restrict ds Documentation{..} =
+    Documentation
+        { getDocumentation =
+            Map.restrictKeys getDocumentation $ internals <> typs
+        }
+  where
+    typs = Set.map Typ $ Map.keysSet ds
+    internals =
+        foldMap (\(name, typ) -> everything (<>) (match name) typ)
+            $ Map.assocs ds
+    match :: TypName -> Typ -> Set Identifier
+    match tn = \case
+        ProductN fields ->
+            fold $ do
+                (fn, _typ) <- fields
+                pure $ Set.singleton $ Field tn fn
+        SumN fields ->
+            fold $ do
+                (fn, _typ) <- fields
+                pure $ Set.singleton $ Constructor tn fn
+        _ -> mempty
 
 shrinkDeclarations :: Declarations -> [Declarations]
 shrinkDeclarations xs = fmap Map.fromList $ shrinkList f $ Map.toList xs

--- a/lib/fine-types/src/Language/FineTypes/Typ/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Typ/Gen.hs
@@ -1,13 +1,30 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Language.FineTypes.Typ.Gen where
 
 import Prelude hiding (round)
 
-import Data.Char (isAlphaNum, isPunctuation, isSymbol, toUpper)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Writer (MonadWriter (tell))
+import Data.Char
+    ( isAlphaNum
+    , isPunctuation
+    , isSpace
+    , isSymbol
+    , toUpper
+    )
+import Data.Foldable (forM_)
 import Data.List (isInfixOf, nub)
 import Data.Traversable (forM)
+import Language.FineTypes.Module
+    ( Documentation (..)
+    , Identifier (..)
+    , Place (..)
+    )
 import Language.FineTypes.Typ
     ( Constraint
     , Constraint1 (..)
@@ -19,9 +36,9 @@ import Language.FineTypes.Typ
     , TypConst (..)
     , TypName
     )
-import Test.QuickCheck
-    ( Gen
-    , arbitrary
+import QuickCheck.GenT
+    ( GenT
+    , arbitrary'
     , choose
     , elements
     , frequency
@@ -29,10 +46,12 @@ import Test.QuickCheck
     , oneof
     , scale
     , shrink
-    , shrinkList
     , suchThat
     , vectorOf
     )
+import Test.QuickCheck (shrinkList)
+
+import qualified Data.Map as Map
 
 -- | If the generated 'Typ' should be concrete or not. 'Concrete' will not contain
 -- 'Abstract' or 'Var' leaves
@@ -49,7 +68,7 @@ type DepthGen = Int
 -- | Whether the generated 'Typ' will be Zero or more complex
 data Branch = Wont | Will
 
-willBranch :: DepthGen -> Gen Branch
+willBranch :: Monad m => DepthGen -> GenT m Branch
 willBranch n =
     frequency
         [ (1, pure Will)
@@ -75,8 +94,9 @@ onTop Top f = f
 onTop Rest _ = mempty
 
 -- | Generate a random 'Typ'.
-genTypFiltered
-    :: (Typ -> Bool)
+genTyp
+    :: (MonadWriter Documentation m, ?typname :: TypName)
+    => (Typ -> Bool)
     -- ^ Whether the generated 'Typ' should be filtered out
     -> WithConstraints
     -- ^ Whether the generated 'Typ' can have constraints or not
@@ -84,8 +104,8 @@ genTypFiltered
     -- ^ Whether the generated 'Typ' should be concrete or not
     -> DepthGen
     -- ^ Maximum depth of the generated 'Typ'
-    -> Gen Typ
-genTypFiltered out = go Top
+    -> GenT m Typ
+genTyp out = go Top
   where
     go round hasC mode depth = do
         branching <- onWill <$> willBranch depth
@@ -113,19 +133,16 @@ genTypFiltered out = go Top
       where
         go' = go Rest hasC mode (depth - 1)
 
-genTyp :: WithConstraints -> Mode -> DepthGen -> Gen Typ
-genTyp = genTypFiltered $ const False
-
-genConstraint :: Int -> Gen Constraint
+genConstraint :: Monad m => Int -> GenT m Constraint
 genConstraint 0 = pure []
 genConstraint n = listOf1 $ genConstraint1 $ n - 1
 
-genConstraint1 :: Int -> Gen Constraint1
+genConstraint1 :: Monad m => Int -> GenT m Constraint1
 genConstraint1 n =
     oneof
         $ [Braces <$> genConstraint n | n > 0]
             <> [ Token
-                    <$> listOf1 (arbitrary `suchThat` goodChar)
+                    <$> listOf1 (arbitrary' `suchThat` goodChar)
                         `suchThat` goodToken
                ]
 
@@ -136,7 +153,7 @@ goodChar :: Char -> Bool
 goodChar x =
     (isSymbol x || isAlphaNum x || isPunctuation x) && x `notElem` " {}"
 
-genConstrainedTyp :: Mode -> Gen Typ
+genConstrainedTyp :: Monad m => Mode -> GenT m Typ
 genConstrainedTyp mode = do
     constraintDepth <- choose (1, 2)
     c <- genConstraint constraintDepth
@@ -151,21 +168,21 @@ genConstrainedTyp mode = do
                 <> always [Zero <$> genConst]
                 <> complete [Var <$> genVarName]
 
-genTagged :: Gen [a] -> Gen Typ -> Gen [(a, Typ)]
+genTagged :: Monad m => GenT m [a] -> GenT m Typ -> GenT m [(a, Typ)]
 genTagged gen f = do
     names <- gen
     forM names $ \name -> (,) name <$> f
 
-genTwoOpen :: Gen OpTwo
+genTwoOpen :: Monad m => GenT m OpTwo
 genTwoOpen = elements [Sum2, Product2]
 
-genTwoClose :: Gen OpTwo
+genTwoClose :: Monad m => GenT m OpTwo
 genTwoClose = elements [PartialFunction, FiniteSupport]
 
-genOne :: Gen OpOne
+genOne :: Monad m => GenT m OpOne
 genOne = elements [Option, Sequence, PowerSet]
 
-genConst :: Gen TypConst
+genConst :: Monad m => GenT m TypConst
 genConst =
     elements
         [ Bool
@@ -179,22 +196,27 @@ genConst =
 notPrivate :: String -> Bool
 notPrivate = not . flip elem ["Text", "Bytes", "Bool", "Unit"]
 
-genNames :: Gen [String]
+genNames :: Monad m => GenT m [String]
 genNames =
     fmap nub
         $ logScale 2
         $ listOf1
             genName
 
-genName :: Gen [Char]
+genName :: Monad m => GenT m [Char]
 genName =
     vectorOf 4
         $ elements ['a' .. 'z']
 
-genConstructors :: Gen [ConstructorName]
-genConstructors = genNames
+genConstructors
+    :: (?typname :: TypName, MonadWriter Documentation m)
+    => GenT m [ConstructorName]
+genConstructors = do
+    ns <- genNames
+    forM_ ns $ \n -> genDocumentation (Constructor ?typname n)
+    pure ns
 
-genVarName :: Gen TypName
+genVarName :: Monad m => GenT m TypName
 genVarName = (capitalise <$> genName) `suchThat` notPrivate
 
 capitalise :: [Char] -> [Char]
@@ -202,10 +224,15 @@ capitalise = \case
     [] -> []
     (x : xs) -> toUpper x : xs
 
-genFields :: Gen [FieldName]
-genFields = genNames
+genFields
+    :: (MonadWriter Documentation m, ?typname :: TypName)
+    => GenT m [FieldName]
+genFields = do
+    ns <- genNames
+    forM_ ns $ \n -> genDocumentation (Field ?typname n)
+    pure ns
 
-logScale :: Double -> Gen a -> Gen a
+logScale :: Monad m => Double -> GenT m a -> GenT m a
 logScale n = scale logN
   where
     logN x = floor $ logBase n $ 1 + fromIntegral x
@@ -238,3 +265,37 @@ shrinkConstraint1 :: Constraint1 -> [Constraint1]
 shrinkConstraint1 = \case
     Braces c -> Braces <$> shrinkConstraint c
     Token xs -> Token <$> shrink xs
+
+genDocumentation :: MonadWriter Documentation m => Identifier -> GenT m ()
+genDocumentation i = do
+    places <- elements placesChoices
+    forM_ places $ \place -> do
+        docs <-
+            fmap (take 3)
+                $ listOf1 (arbitrary' `suchThat` allowedChars)
+                    `suchThat` noHeadingSpace
+                    `suchThat` correctInside place
+        lift $ tell $ Documentation $ Map.singleton i $ Map.singleton place docs
+
+placesChoices :: [[Place]]
+placesChoices =
+    [ []
+    , [After]
+    , [Before]
+    , [BeforeMultiline]
+    , [Before, After]
+    , [BeforeMultiline, After]
+    ]
+
+allowedChars :: Char -> Bool
+allowedChars x = isSpace x || isAlphaNum x || isPunctuation x || isSymbol x
+
+noHeadingSpace :: String -> Bool
+noHeadingSpace = \case
+    [] -> True
+    (x : _) -> not $ isSpace x
+
+correctInside :: Place -> [Char] -> Bool
+correctInside = \case
+    BeforeMultiline -> not . ("-}" `isInfixOf`)
+    _ -> not . ('\n' `elem`)

--- a/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Generate random 'Value's of a given 'Typ'.
@@ -12,15 +13,16 @@ import Prelude
 import Control.Monad (replicateM)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
+import Control.Monad.Trans.Writer (runWriter)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+import Language.FineTypes.Module.Gen (logScaleGen)
 import Language.FineTypes.Typ (Typ)
 import Language.FineTypes.Typ.Gen
     ( DepthGen
     , Mode (..)
     , WithConstraints (..)
-    , genTypFiltered
-    , logScale
+    , genTyp
     )
 import Language.FineTypes.Value
     ( OneF (..)
@@ -28,6 +30,7 @@ import Language.FineTypes.Value
     , Value (..)
     , ZeroF (..)
     )
+import QuickCheck.GenT (runGenT, suchThat)
 import Test.QuickCheck
     ( Arbitrary (arbitrary)
     , Gen
@@ -59,7 +62,7 @@ exceptGenValue = ExceptT . genTypValue
 -- | Generate a random list of the given length under a monad transformer.
 listOfT :: (Monad (t Gen), MonadTrans t) => t Gen a -> t Gen [a]
 listOfT f = do
-    l <- lift $ logScale 2 getSize
+    l <- lift $ logScaleGen 2 getSize
     replicateM l f
 
 -- | Generate a random 'Value' of the given 'Typ' or report the first 'Typ' that
@@ -122,11 +125,16 @@ genTypValue typ =
 
 genTypAndValue
     :: (Typ -> Bool)
+    -> (Typ -> Bool)
     -> WithConstraints
     -> Mode
     -> DepthGen
     -> Gen (Typ, Either Typ Value)
-genTypAndValue filteringOut contraints concreteness depth = do
-    typ <- genTypFiltered filteringOut contraints concreteness depth
+genTypAndValue topLevelFilterIn filteringOut contraints concreteness depth = do
+    (typ, _) <-
+        fmap runWriter . runGenT
+            $ let ?typname = error "genValue: ?typname"
+              in  genTyp filteringOut contraints concreteness depth
+                    `suchThat` topLevelFilterIn
     evalue <- genTypValue typ
     pure (typ, evalue)

--- a/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Generate random 'Value's of a given 'Typ'.
@@ -11,6 +10,7 @@ where
 import Prelude
 
 import Control.Monad (replicateM)
+import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import Control.Monad.Trans.Writer (runWriter)
@@ -132,9 +132,9 @@ genTypAndValue
     -> Gen (Typ, Either Typ Value)
 genTypAndValue topLevelFilterIn filteringOut contraints concreteness depth = do
     (typ, _) <-
-        fmap runWriter . runGenT
-            $ let ?typname = error "genValue: ?typname"
-              in  genTyp filteringOut contraints concreteness depth
-                    `suchThat` topLevelFilterIn
+        fmap (runWriter . flip runReaderT (error "genValue: ?typname"))
+            $ runGenT
+            $ genTyp filteringOut contraints concreteness depth
+                `suchThat` topLevelFilterIn
     evalue <- genTypValue typ
     pure (typ, evalue)

--- a/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/SchemaSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/SchemaSpec.hs
@@ -60,7 +60,13 @@ spec = do
     describe "Schema derived from a module" $ do
         prop "validates json values computed from the same module"
             $ forAll
-                (genTypAndValue unsupported WithoutConstraints Concrete 6)
+                ( genTypAndValue
+                    (const True)
+                    unsupported
+                    WithoutConstraints
+                    Concrete
+                    6
+                )
             $ \(typ, evalue) ->
                 counterexample (jsonInfo typ evalue)
                     $ classify (depth typ > 3) "3-deep"

--- a/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/ValueSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/ValueSpec.hs
@@ -16,10 +16,9 @@ import Language.FineTypes.Typ
 import Language.FineTypes.Typ.Gen
     ( Mode (..)
     , WithConstraints (..)
-    , genTypFiltered
     )
 import Language.FineTypes.Value (Value, hasTyp)
-import Language.FineTypes.Value.Gen (genTypValue)
+import Language.FineTypes.Value.Gen (genTypAndValue, genTypValue)
 import Test.Hspec (Spec, describe, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck
@@ -28,7 +27,6 @@ import Test.QuickCheck
     , classify
     , counterexample
     , forAll
-    , suchThat
     )
 import Text.Pretty.Simple (pShow)
 
@@ -107,10 +105,13 @@ concert :: Typ -> Bool
 concert = or <$> sequence [isZero, isOne, isTwo, isProductN, isSumN]
 
 genValue :: (Typ -> Bool) -> Gen (Typ, Either Typ Value)
-genValue f = do
-    typ <- genTypFiltered unsupported WithoutConstraints Concrete 6 `suchThat` f
-    r <- genTypValue typ
-    pure (typ, r)
+genValue f =
+    genTypAndValue
+        f
+        unsupported
+        WithoutConstraints
+        Concrete
+        6
 
 unsupported :: Typ -> Bool
 unsupported = \case

--- a/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
@@ -94,10 +94,10 @@ fixDocumentationIndentation m = m{moduleDocumentation = docs'}
 specParserOnFile :: FilePath -> Spec
 specParserOnFile fp = do
     describe ("on file " <> fp) $ do
-        it "parses the file" $ do
+        it ("parses the file " <> fp) $ do
             file <- readFile fp
             parseFineTypes' file `shouldSatisfy` isRight
-        it "detects undefined names" $ do
+        it ("detects undefined names on " <> fp) $ do
             file <- readFile fp
             Just m <- pure $ parseFineTypes file
             collectNotInScope m `shouldBe` Set.empty

--- a/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/ParserSpec.hs
@@ -12,7 +12,8 @@ import Data.Foldable (fold, toList)
 import Data.TreeDiff.QuickCheck (ediffEq)
 import Language.FineTypes.Module
     ( Documentation (..)
-    , Identifier (Constructor, Field)
+    , Identifier (..)
+    , IdentifierDocumentation
     , Module (..)
     , Place (..)
     , collectNotInScope
@@ -35,7 +36,12 @@ import Test.Hspec
     , shouldSatisfy
     )
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (classify, counterexample, forAllShrink, property)
+import Test.QuickCheck
+    ( classify
+    , counterexample
+    , forAllShrink
+    , property
+    )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -54,11 +60,13 @@ spec = do
     describe "pretty print + parse idempotency" $ do
         specPrettyOnFile "test/data/ParseTestBabbage.fine"
         specPrettyOnFile "test/data/HaskellUTxO.fine"
+        specParserOnFile "test/data/DocumentationTest.fine"
         prop "holds on random generated modules"
             $ forAllShrink genModule shrinkModule
+            -- forAll genModule
             $ \m ->
                 let output = prettyPrintModule m
-                    m' = parseFineTypes output
+                    m' = fixDocumentationIndentation <$> parseFineTypes output
                 in  classify (allPositive $ countTyps m) "fat"
                         $ property
                         $ counterexample (show (m', m))
@@ -66,6 +74,22 @@ spec = do
                         $ counterexample (show $ parseFineTypes' output)
                         $ ediffEq m'
                         $ Just m
+
+-- this is a hack necessary because the pretty printer introduces 4 characters
+-- indentation for multiline documentation on fields and constructors
+fixDocumentationIndentation :: Module -> Module
+fixDocumentationIndentation m = m{moduleDocumentation = docs'}
+  where
+    Documentation docs = moduleDocumentation m
+    docs' = Documentation $ Map.mapWithKey fix docs
+    fix :: Identifier -> IdentifierDocumentation -> IdentifierDocumentation
+    fix (Typ{}) = id
+    fix _ = Map.adjust stripIndentation BeforeMultiline
+      where
+        stripIndentation [] = []
+        stripIndentation ('\n' : ' ' : ' ' : ' ' : ' ' : xs) =
+            '\n' : stripIndentation xs
+        stripIndentation (x : xs) = x : stripIndentation xs
 
 specParserOnFile :: FilePath -> Spec
 specParserOnFile fp = do
@@ -98,7 +122,7 @@ specPrettyOnFile fp = do
         file <- readFile fp
         Just m <- pure $ parseFineTypes file
         let output = prettyPrintModule m
-            m' = parseFineTypes output
+            m' = fixDocumentationIndentation <$> parseFineTypes output
         m' `shouldBe` Just m
 
 {-----------------------------------------------------------------------------

--- a/lib/fine-types/test/Language/FineTypes/ValueSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/ValueSpec.hs
@@ -11,7 +11,13 @@ import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (Gen, forAll)
 
 genValue :: Gen (Typ, Either Typ Value)
-genValue = genTypAndValue (const False) WithoutConstraints Concrete 6
+genValue =
+    genTypAndValue
+        (const True)
+        (const False)
+        WithoutConstraints
+        Concrete
+        6
 
 spec :: Spec
 spec = do

--- a/lib/fine-types/test/data/DocumentationTest.fine
+++ b/lib/fine-types/test/data/DocumentationTest.fine
@@ -30,3 +30,10 @@ C =
     -}
     c3 : ℤ? --^ Documentation text after a constructor name.
   };
+
+D =
+    { {-| empty line in indented multiline comment
+
+    -}
+    d1 : Unit
+};


### PR DESCRIPTION
- [x] avoid hacky ImplicitParams to pass the TypName to genTyp and go with ReaderT. Required to patch GenT lib with an MFunctor instance (https://github.com/nikita-volkov/QuickCheck-GenT/pull/9)