### PR TITLE
[ADP-3161] Add executable for fine-types with conversion to json schema

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set positional-arguments
+
 seed := "0"
 
 default:
@@ -32,4 +34,7 @@ repl:
     cabal repl -v0 -O0 -j fine-types
 
 prepare: format lint build0 test
-ghci:
+
+
+@run *args='--help':
+    cabal exec -v0 -O0 -j fine-types -- $@

--- a/lib/fine-types/app/Main.hs
+++ b/lib/fine-types/app/Main.hs
@@ -1,0 +1,4 @@
+import Prelude
+
+main :: IO ()
+main = pure ()

--- a/lib/fine-types/app/Main.hs
+++ b/lib/fine-types/app/Main.hs
@@ -1,4 +1,75 @@
+{-# LANGUAGE RecordWildCards #-}
+
 import Prelude
 
+import Control.Exception (catch)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Function ((&))
+import Data.Maybe (fromMaybe)
+import Language.FineTypes.Export.OpenAPI.Schema (schemaFromModule)
+import Language.FineTypes.Parser (parseFineTypes')
+import Main.Utf8 (withUtf8)
+import Options
+    ( Commands (Convert)
+    , ConvertOptions (..)
+    , Format (..)
+    , LogFile (..)
+    , Options (..)
+    , parseOptions
+    )
+import System.Exit (exitFailure)
+import System.IO (Handle, IOMode (..), hPutStrLn, stderr, stdout, withFile)
+import Text.Megaparsec (errorBundlePretty)
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Yaml.Pretty as Y
+
 main :: IO ()
-main = pure ()
+main = withUtf8 $ do
+    Options{..} <- parseOptions
+    case optCommand of
+        Convert co -> convert optLogFile co
+
+withLogHandle :: LogFile -> (Handle -> IO a) -> IO a
+withLogHandle StdOut f = f stdout
+withLogHandle StdErr f = f stderr
+withLogHandle (LogFile fp) f = withFile fp WriteMode f
+
+withLogPutLn :: LogFile -> ((String -> IO ()) -> IO a) -> IO a
+withLogPutLn q f = withLogHandle q $ f . hPutStrLn
+
+convert :: LogFile -> ConvertOptions -> IO ()
+convert logFile ConvertOptions{..} = do
+    withLogPutLn logFile $ \logMe -> do
+        m <- case optInput of
+            Nothing -> do
+                logMe "Reading from stdin"
+                getContents
+            Just inputFile ->
+                readFile inputFile `catch` \e -> do
+                    logMe
+                        $ "Failed to read input file "
+                            <> inputFile
+                            <> " : "
+                            <> show (e :: IOError)
+                    exitFailure
+        logMe
+            $ "Converting "
+                <> fromMaybe "<stdin>" optInput
+                <> " to "
+                <> fromMaybe "<stdout>" optOutput
+        case parseFineTypes' m of
+            Left e -> do
+                logMe "Failed to parse input file:"
+                logMe $ errorBundlePretty e
+            Right m' -> do
+                let schema = schemaFromModule m'
+                case optFormat of
+                    Json ->
+                        encodePretty schema
+                            & maybe BL.putStr BL.writeFile optOutput
+                    Yaml ->
+                        Y.encodePretty Y.defConfig schema
+                            & maybe B.putStr B.writeFile optOutput
+                logMe "Success!"

--- a/lib/fine-types/app/Options.hs
+++ b/lib/fine-types/app/Options.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Options where
+
+import Prelude
+
+import Data.Foldable (asum)
+import Options.Applicative
+    ( InfoMod
+    , Parser
+    , ReadM
+    , command
+    , eitherReader
+    , execParser
+    , flag
+    , flag'
+    , fullDesc
+    , header
+    , help
+    , helper
+    , hsubparser
+    , info
+    , long
+    , metavar
+    , option
+    , progDesc
+    , short
+    , strOption
+    , value
+    , (<**>)
+    )
+
+data Options = Options
+    { optCommand :: Commands
+    , optLogFile :: LogFile
+    }
+
+newtype Commands = Convert ConvertOptions
+
+data Format = Json | Yaml
+
+data ConvertOptions = ConvertOptions
+    { optInput :: Maybe FilePath
+    , optOutput :: Maybe FilePath
+    , optFormat :: Format
+    }
+
+data LogFile = LogFile FilePath | StdOut | StdErr
+
+parseOptions :: IO Options
+parseOptions =
+    execParser
+        $ info (options <**> helper)
+        $ fullDesc
+            <> progDesc "Run fine-types commands"
+            <> header "fine-types - a tool for working with fine-types modules"
+  where
+    options = Options <$> commands <*> optionLogFile
+
+    commands =
+        hsubparser
+            $ mconcat
+                [ command "convert"
+                    $ info (Convert <$> convertOptions) convertDescr
+                    -- other commands go here
+                ]
+
+convertDescr :: InfoMod Commands
+convertDescr =
+    mconcat
+        [ progDesc "Convert a fine-types module to a json schema"
+        , header "fine-types convert - convert a fine-types module to a schema"
+        ]
+
+convertOptions :: Parser ConvertOptions
+convertOptions = do
+    input <-
+        option fileReader
+            $ mconcat
+                [ long "input"
+                , short 'i'
+                , metavar "FILE"
+                , help "input file (stdin if not specified or --)"
+                , value Nothing
+                ]
+    output <-
+        option fileReader
+            $ mconcat
+                [ long "output"
+                , short 'o'
+                , metavar "FILE"
+                , help "output file (stdout if not specified or --)"
+                , value Nothing
+                ]
+    format <-
+        asum
+            [ flag' Json
+                $ mconcat
+                    [ long "json"
+                    , help "output in json format"
+                    ]
+            , flag Yaml Yaml
+                $ mconcat
+                    [ long "yaml"
+                    , help "output in yaml format (default format)"
+                    ]
+            ]
+    pure $ ConvertOptions input output format
+
+fileReader :: ReadM (Maybe FilePath)
+fileReader = eitherReader $ \case
+    "--" -> Right Nothing
+    file -> Right $ Just file
+
+optionLogFile :: Parser LogFile
+optionLogFile =
+    asum
+        [ fmap LogFile
+            $ strOption
+            $ mconcat
+                [ long "log-file"
+                , metavar "FILE"
+                , help "log file"
+                ]
+        , flag' StdOut
+            $ mconcat
+                [ long "log-stdout"
+                , help "log to stdout"
+                ]
+        , flag StdErr StdErr
+            $ mconcat
+                [ long "log-stderr"
+                , help "log to stderr (default log destination)"
+                ]
+        ]

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -110,3 +110,17 @@ test-suite unit
     Language.FineTypes.Export.OpenAPI.ValueSpec
     Language.FineTypes.ParserSpec
     Language.FineTypes.ValueSpec
+
+executable fine-types
+  import:      language, opts-exe
+  hs-source-dirs:
+    app
+  main-is:
+    Main.hs
+  build-depends:
+    , base
+    , optparse-applicative
+    , fine-types
+  other-modules:
+
+```

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -118,9 +118,13 @@ executable fine-types
   main-is:
     Main.hs
   build-depends:
+    , aeson-pretty
     , base
+    , bytestring
+    , megaparsec
     , optparse-applicative
     , fine-types
+    , with-utf8
+    , yaml
   other-modules:
-
-```
+    Options


### PR DESCRIPTION
- [x] added an executable that takes only the command convert
- [x] add support for json and yaml as output format for json schema
- [x] report parsing errors in human readable format