### PR TITLE
[ADP-3167] Implement basic package system

### DIFF
--- a/doc/packages/howto.md
+++ b/doc/packages/howto.md
@@ -1,0 +1,103 @@
+# How to use packages
+
+This document gives example of how to use [FineType's packaging system][spec].
+
+  [spec]: ./spec
+
+🚧 FIXME: This is a possible design for now. Subject to change and implementation.
+
+# Command overview
+
+* `fine-types check` — checks that a package passes all static checks.
+
+* Error messages from `fine-types` should follow the [GNU Coding Standards for formatting error messages][errors] — I couldn't find any other standard.
+
+  [errors]: https://www.gnu.org/prep/standards/html_node/Errors.html
+
+# Examples
+
+## Check that imports are complete
+
+Given the following two modules and package definition,
+
+```
+-- file: ./X.fine
+module X where
+
+A = ℕ;
+B = A + Bytes?;
+
+-- file: ./Y.fine
+module Y where
+
+import X(A,B,C);
+
+D = A 𐄂 B 𐄂 C;
+
+-- file: ./P.fine
+package P where
+
+module X;
+module Y;
+```
+
+performing the static check on the package `P`
+
+```
+fine-types check -i P.fine
+```
+
+should complain
+
+```
+P.fine:4:-Y.fine:2: Module X does not export identifier C.
+```
+
+## Checking two modules for equality
+
+Given two definitions of a module `Address`, both depending on a module with signature `Crypto`,
+
+```
+-- file: ./Crypto.fine
+signature Crypto where
+
+KeyHash;
+ScriptHash;
+
+-- file: ./Allegra/Address.fine
+module Address where
+
+import Crypto(KeyHash, ScriptHash);
+
+[…]
+
+-- file: ./Shelley/Address.fine
+module Address where
+
+import Crypto(KeyHash, ScriptHash);
+
+[…]
+```
+
+the following package definition
+
+```
+-- file: ./Allegra/DiffAllegra.fine
+package DiffAllegra where
+
+module Crypto;
+module Address;
+module ShelleyAddress = Address from "../Shelley/Address.fine";
+
+assert Address equal ShelleyAddress;
+```
+
+passes the static check if the assertion is true, i.e. if the two modules `Address` export the same list of identifiers which represent equal types.
+
+In other words, running the command
+
+```
+fine-types check -i ./Allegra/DiffAllegra.fine
+```
+
+succeeds with no output and exit code `EXIT_SUCCESS` (= `0`).

--- a/doc/packages/spec.md
+++ b/doc/packages/spec.md
@@ -1,0 +1,86 @@
+# Packages in FineTypes
+
+In larger projects, it is helpful to organize type definition in separate files. FineTypes' packaging system allows you to do that.
+
+FineType files come in three different varieties:
+
+1. module
+2. signature
+3. package
+
+*Modules* contain the actual type definitions. *Signatures* are brief lists of types that are yet to be defined, and *packages* allow you to specify how multiple modules and signatures are combined.
+
+In the simplest case, your project consists of a single *module* file. For more complicated projects, consider using *packages* and maybe even *signatures*.
+
+The packaging system for FineTypes is a stripped-down dialect of [Backpack'14][backpack14], a packaging system conceived for the Haskell programming language. (See [Backpack in GHC][backpack17] for the current status in Haskell.)
+
+  [backpack14]: https://plv.mpi-sws.org/backpack/
+  [backpack17]: https://gitlab.haskell.org/ghc/ghc/-/wikis/backpack
+
+## Module
+
+*Modules* are the most important parts of your project, they contain the actual type definitions.
+
+A module can `import` types from other modules or signatures. Consider the following example:
+
+```
+module ModuleX where
+
+import ModuleY (Q);
+
+A = Bytes;
+B = Int;
+C = (A × B?) + Q;
+```
+
+Here, the module `ModuleX` imports the name `Q` from `ModuleY`. By itself, `ModuleX` does not contain enough information to specify the type, say, `C` completely; we have to combine it with the actual definition of `Q` in `ModuleY`. A *package* describes where to find and how to combine modules.
+
+Instead of a matching the `import` with a module `ModuleY`, we can also combine it with a *signature* `ModuleY`. This leaves the definition of the type `Q` intentionally open.
+
+## Signatures
+
+🚧 FIXME: Signatures to be implemented
+
+A *signature* file contains a list of types to be defined.
+
+Example:
+
+```
+signature ModuleY where
+
+Q;
+P;
+```
+
+Not much to see here. Signatures can be useful when
+
+* exporting to other languages when some types are specified externally, and when
+* performing static checks on some modules without including their dependencies in the check.
+
+## Package
+
+A *package* is essentially a list of modules. Importantly, modules must be listed in an order in which they can import each other: Each module must be listed after the modules that it imports. Instead of a module, a signature is also acceptable.
+
+Example:
+
+```
+package Foo where
+
+module ModuleY; -- must be listed *before* ModuleX
+module ModuleX; -- import statements are resolved using the definitions above
+```
+
+One package can `include` another package. This means that all of its modules are brought into scope.
+
+🚧 FIXME: To be reconsidered:
+By convention, writing `module X` will refer to the file `./X.fine`. Module names containing by dots, such as `Very.Long.Module.Name`, will refer to files where the dots are replaced by path separators, that is to the file `./Very/Long/Module/Name.fine`. This convention can be overwritten.
+
+🚧 FIXME: To be implemented:
+If you want to bring only selected modules into scope, use an explicit list with parentheses. While doing so, you can rename with `as`.
+
+```
+package Bar where
+
+include Foo (ModuleX, ModuleY as Y);
+```
+

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -55,6 +55,7 @@ library
     , bytestring
     , containers
     , deepseq >= 1.4.4
+    , filepath >= 1.4.2
     , insert-ordered-containers
     , megaparsec ^>= 9.2.1
     , openapi3
@@ -75,12 +76,18 @@ library
     Language.FineTypes.Module
     Language.FineTypes.Module.Gen
     Language.FineTypes.Module.PrettyPrinter
+    Language.FineTypes.Package
     Language.FineTypes.Parser
     Language.FineTypes.Typ
     Language.FineTypes.Typ.Gen
     Language.FineTypes.Typ.PrettyPrinter
     Language.FineTypes.Value
     Language.FineTypes.Value.Gen
+  other-modules:
+    Language.FineTypes.Package.Compile
+    Language.FineTypes.Package.Content
+    Language.FineTypes.Package.Description
+    Language.FineTypes.Package.Parser
 
 test-suite unit
   import:      language, opts-exe

--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -114,6 +114,7 @@ test-suite unit
     Language.FineTypes.Cardano.Ledger.ShelleySpec
     Language.FineTypes.Export.OpenAPI.SchemaSpec
     Language.FineTypes.Export.OpenAPI.ValueSpec
+    Language.FineTypes.PackageSpec
     Language.FineTypes.ParserSpec
     Language.FineTypes.ValueSpec
 

--- a/lib/fine-types/src/Language/FineTypes/Package.hs
+++ b/lib/fine-types/src/Language/FineTypes/Package.hs
@@ -1,0 +1,28 @@
+-- | Convenient packaging of 'Package'
+-- and 'PackageDescription' functionality.
+module Language.FineTypes.Package
+    ( -- * Package
+      Package (..)
+    , emptyPackage
+    , includePackage
+    , addModule
+
+      -- * Package descriptions
+    , PackageDescription (..)
+    , PackageName
+    , Statement (..)
+    , Source (..)
+    , parsePackageDescription
+    , compilePackageDescription
+
+      -- * Error types
+    , ErrParsePackage
+    , ErrCompilePackage
+    , ErrIncludePackage
+    , ErrAddModule
+    ) where
+
+import Language.FineTypes.Package.Compile
+import Language.FineTypes.Package.Content
+import Language.FineTypes.Package.Description
+import Language.FineTypes.Package.Parser

--- a/lib/fine-types/src/Language/FineTypes/Package/Compile.hs
+++ b/lib/fine-types/src/Language/FineTypes/Package/Compile.hs
@@ -1,0 +1,105 @@
+-- | A package description is a small program which evaluates to a package.
+module Language.FineTypes.Package.Compile
+    ( compilePackageDescription
+    , ErrCompilePackage
+    ) where
+
+import Prelude
+
+import Control.Monad (foldM)
+import Control.Monad.Trans.Except
+    ( ExceptT (..)
+    , except
+    , runExceptT
+    , withExceptT
+    )
+import Language.FineTypes.Module (ModuleName)
+import Language.FineTypes.Package.Content
+    ( ErrAddModule
+    , ErrIncludePackage
+    , Package (..)
+    , addModule
+    , emptyPackage
+    , includePackage
+    )
+import Language.FineTypes.Package.Description
+    ( PackageDescription (..)
+    , PackageName
+    , Source (..)
+    , Statement (..)
+    )
+import Language.FineTypes.Package.Parser
+    ( ErrParsePackage
+    , parsePackageDescription
+    )
+import Language.FineTypes.Parser (ErrParseModule, parseFineTypes')
+import System.FilePath ((</>))
+import System.IO.Error (catchIOError)
+
+{-----------------------------------------------------------------------------
+    Package compiler
+------------------------------------------------------------------------------}
+
+data ErrCompilePackage
+    = ErrFile IOError
+    | ErrParseModuleError ModuleName ErrParseModule
+    | ErrParsePackageError PackageName ErrParsePackage
+    | ErrCompilePackage PackageName ErrCompilePackage
+    | ErrIncludePackage PackageName ErrIncludePackage
+    | ErrAddModule ModuleName ErrAddModule
+    deriving (Eq, Show)
+
+-- | Compile a package description to a 'Package' or
+-- return a descriptive error message.
+--
+-- The first argument is a directory which is used as base
+-- for resolving relative filenames.
+compilePackageDescription
+    :: FilePath
+    -> PackageDescription
+    -> IO (Either ErrCompilePackage Package)
+compilePackageDescription dir =
+    runExceptT
+        . foldM (execStatement dir) emptyPackage
+        . packageStatements
+
+execStatement
+    :: FilePath
+    -> Package
+    -> Statement
+    -> ExceptT ErrCompilePackage IO Package
+execStatement dir pkg (Include pkgName source) = do
+    file <- loadSource dir source
+    pkgDescription <-
+        exceptT (ErrParsePackageError pkgName)
+            $ parsePackageDescription file
+    include <-
+        withExceptT (ErrCompilePackage pkgName)
+            $ ExceptT
+            $ compilePackageDescription dir pkgDescription
+    -- FIXME: Better directory `dir`
+    exceptT (ErrIncludePackage pkgName)
+        $ includePackage include pkg
+execStatement dir pkg (Module modName source) = do
+    file <- loadSource dir source
+    m <-
+        exceptT (ErrParseModuleError modName)
+            $ parseFineTypes' file
+    exceptT (ErrAddModule modName)
+        $ addModule m pkg
+execStatement _ pkg (Assert _) =
+    pure pkg
+
+loadSource
+    :: FilePath
+    -> Source
+    -> ExceptT ErrCompilePackage IO String
+loadSource dir (File path) = withExceptT ErrFile . ExceptT $ do
+    (Right <$> readFile (dir </> path)) `catchIOError` (pure . Left)
+
+{-----------------------------------------------------------------------------
+    Utilities
+------------------------------------------------------------------------------}
+
+exceptT :: (e -> e') -> Either e a -> ExceptT e' IO a
+exceptT f = withExceptT f . except

--- a/lib/fine-types/src/Language/FineTypes/Package/Content.hs
+++ b/lib/fine-types/src/Language/FineTypes/Package/Content.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+
+-- | A package contains named modules.
+module Language.FineTypes.Package.Content
+    ( Package (..)
+    , emptyPackage
+    , includePackage
+    , addModule
+
+      -- * Error types
+    , ErrIncludePackage (..)
+    , ErrAddModule (..)
+    ) where
+
+import Prelude
+
+import Data.Foldable (fold)
+import Data.Map (Map)
+import Data.Set (Set)
+import Language.FineTypes.Module
+    ( Import (getImportNames)
+    , Module (..)
+    , ModuleName
+    )
+import Language.FineTypes.Typ (TypName)
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+{-----------------------------------------------------------------------------
+    Package content
+------------------------------------------------------------------------------}
+
+-- | A package is a collection of module or signature definitions.
+newtype Package = Package
+    { packageModules :: Map ModuleName Module
+    }
+    deriving (Eq, Show)
+
+emptyPackage :: Package
+emptyPackage = Package Map.empty
+
+newtype ErrIncludePackage
+    = ErrModulesAlreadyInScope (Set ModuleName)
+    deriving (Eq, Show)
+
+-- | Include a package in the current package if possible.
+includePackage
+    :: Package
+    -> Package
+    -> Either ErrIncludePackage Package
+includePackage include package
+    | not (Set.null invalidModules) =
+        Left $ ErrModulesAlreadyInScope invalidModules
+    | otherwise =
+        Right
+            package{packageModules = modulesInclude <> modulesPackage}
+  where
+    modulesInclude = packageModules include
+    modulesPackage = packageModules package
+
+    invalidModules =
+        Map.keysSet modulesInclude
+            `Set.intersection` Map.keysSet modulesPackage
+
+data ErrAddModule
+    = ErrModuleAlreadyInScope
+    | ErrImportNotInScope (Set (ModuleName, TypName))
+    deriving (Eq, Ord, Show)
+
+-- | Add a module to the current package if possible.
+addModule
+    :: Module -> Package -> Either ErrAddModule Package
+addModule mo@Module{..} Package{..}
+    | moduleName `Map.member` packageModules =
+        Left ErrModuleAlreadyInScope
+    | not (Set.null invalidImports) =
+        Left $ ErrImportNotInScope invalidImports
+    | otherwise =
+        Right
+            Package
+                { packageModules = Map.insert moduleName mo packageModules
+                }
+  where
+    -- FIXME: Substitute provenance for all the defined 'Typ'!.
+
+    invalidImports = fold $ Map.mapWithKey invalidImport moduleImports
+    invalidImport m =
+        Set.map (m,)
+            . Set.filter (not . (`isDefinedIn` m))
+            . getImportNames
+
+    isDefinedIn :: TypName -> ModuleName -> Bool
+    isDefinedIn typName modName =
+        case Map.lookup modName packageModules of
+            Nothing -> False
+            Just Module{moduleDeclarations = ds} ->
+                typName `Map.member` ds

--- a/lib/fine-types/src/Language/FineTypes/Package/Description.hs
+++ b/lib/fine-types/src/Language/FineTypes/Package/Description.hs
@@ -1,0 +1,34 @@
+-- | A package description is a small program which evaluates to a package.
+module Language.FineTypes.Package.Description where
+
+import Prelude
+
+import Language.FineTypes.Module (ModuleName)
+
+{-----------------------------------------------------------------------------
+    Package Description
+------------------------------------------------------------------------------}
+type PackageName = String
+
+-- | A 'PackageDescription' is a sequence of 'Statement' that evaluate
+-- to a 'Package'.
+data PackageDescription = PackageDescription
+    { packageName :: PackageName
+    , packageStatements :: [Statement]
+    }
+    deriving (Eq, Show)
+
+data Statement
+    = Include PackageName Source
+    | Module ModuleName Source
+    | Assert Assertion
+    deriving (Eq, Show)
+
+newtype Source
+    = File FilePath
+    deriving (Eq, Show)
+
+{-----------------------------------------------------------------------------
+    Assertions
+------------------------------------------------------------------------------}
+type Assertion = ()

--- a/lib/fine-types/src/Language/FineTypes/Package/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Package/Parser.hs
@@ -1,0 +1,82 @@
+module Language.FineTypes.Package.Parser
+    ( ErrParsePackage
+    , parsePackageDescription
+    ) where
+
+import Prelude
+
+import Data.Void (Void)
+import Language.FineTypes.Package.Description
+    ( PackageDescription (PackageDescription)
+    , PackageName
+    , Source (..)
+    , Statement (..)
+    )
+import Language.FineTypes.Parser
+    ( moduleName
+    , space
+    , symbol
+    , typName
+    )
+import Text.Megaparsec
+    ( ParseErrorBundle
+    , Parsec
+    , between
+    , endBy
+    , parse
+    , takeWhileP
+    , (<|>)
+    )
+
+import qualified Text.Megaparsec.Char as C
+
+{-----------------------------------------------------------------------------
+    Exported functions
+------------------------------------------------------------------------------}
+parsePackageDescription :: String -> Either ErrParsePackage PackageDescription
+parsePackageDescription = parse packageFull ""
+
+type ErrParsePackage = ParseErrorBundle String Void
+
+{-----------------------------------------------------------------------------
+    Parser
+------------------------------------------------------------------------------}
+
+type Parser = Parsec Void String
+
+packageFull :: Parser PackageDescription
+packageFull = space *> package
+
+package :: Parser PackageDescription
+package =
+    PackageDescription
+        <$ symbol "package"
+        <*> packageName
+        <* symbol "where"
+        <*> statements
+
+statements :: Parser [Statement]
+statements = statement `endBy` symbol ";"
+
+statement :: Parser Statement
+statement =
+    (Include <$ symbol "include" <*> packageName <*> source)
+        <|> (Module <$ symbol "module" <*> moduleName <*> source)
+        <|> (Assert () <$ symbol "assert")
+
+source :: Parser Source
+source =
+    File
+        <$ symbol "from"
+        <*> filePath
+
+{-----------------------------------------------------------------------------
+    Lexer
+------------------------------------------------------------------------------}
+packageName :: Parser PackageName
+packageName = typName
+
+filePath :: Parser FilePath
+filePath =
+    between (C.string "\"") (C.string "\"")
+        $ takeWhileP (Just "character") (`notElem` "\"\n")

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -1,7 +1,14 @@
 -- | Parser for a FineTypes 'Module'.
 module Language.FineTypes.Parser
     ( parseFineTypes
+    , ErrParseModule
     , parseFineTypes'
+
+      -- * Exported lexers
+    , space
+    , symbol
+    , moduleName
+    , typName
     ) where
 
 import Prelude
@@ -71,8 +78,10 @@ import qualified Text.Megaparsec.Char.Lexer as L
 parseFineTypes :: String -> Maybe Module
 parseFineTypes = parseMaybe moduleFull
 
-parseFineTypes' :: String -> Either (ParseErrorBundle String Void) Module
+parseFineTypes' :: String -> Either ErrParseModule Module
 parseFineTypes' = parse moduleFull ""
+
+type ErrParseModule = ParseErrorBundle String Void
 
 {-----------------------------------------------------------------------------
     Parser

--- a/lib/fine-types/test/Language/FineTypes/PackageSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/PackageSpec.hs
@@ -1,0 +1,36 @@
+module Language.FineTypes.PackageSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Either (isRight)
+import Language.FineTypes.Package
+    ( compilePackageDescription
+    , parsePackageDescription
+    )
+import Test.Hspec
+    ( Spec
+    , describe
+    , it
+    , shouldSatisfy
+    )
+
+{-----------------------------------------------------------------------------
+    Tests
+------------------------------------------------------------------------------}
+spec :: Spec
+spec = do
+    describe "Shelley package" $ do
+        let dir = "test/data/Cardano/Ledger"
+            fp = dir <> "/Shelley.fine"
+
+        it "parses" $ do
+            file <- readFile fp
+            parsePackageDescription file `shouldSatisfy` isRight
+
+        it "compiles" $ do
+            file <- readFile fp
+            Right pkg <- pure $ parsePackageDescription file
+            epkg <- compilePackageDescription dir pkg
+            epkg `shouldSatisfy` isRight

--- a/lib/fine-types/test/data/Cardano/Ledger/Shelley.fine
+++ b/lib/fine-types/test/data/Cardano/Ledger/Shelley.fine
@@ -1,0 +1,10 @@
+package Shelley where
+
+module Crypto from "./Shelley/Crypto.fine";
+module PParams from "./Shelley/PParams.fine";
+
+module Address from "./Shelley/Address.fine";
+module Delegation from "./Shelley/Delegation.fine";
+module Tx from "./Shelley/Tx.fine";
+
+module Block from "./Shelley/Block.fine";

--- a/lib/fine-types/test/data/Cardano/Ledger/Shelley/Block.fine
+++ b/lib/fine-types/test/data/Cardano/Ledger/Shelley/Block.fine
@@ -1,7 +1,8 @@
 module Block where
 
+import Address(Slot);
 import Crypto(Proof,Seed,Sig,VKey,VKey_ev);
-import PParams(KESPeriod,ProtVer,Slot);
+import PParams(KESPeriod,ProtVer);
 import Tx(Tx);
 
 {-----------------------------------------------------------------------------

--- a/lib/fine-types/test/data/Cardano/Ledger/Shelley/Tx.fine
+++ b/lib/fine-types/test/data/Cardano/Ledger/Shelley/Tx.fine
@@ -1,8 +1,8 @@
 module Tx where
 
-import Address(Addr, Addr_rwd, Ix);
+import Address(Addr, Addr_rwd, Ix, Slot);
 import Crypto(VKey, Sig, ScriptHash, Script, KeyHash_G);
-import PParams(Coin, Epoch, PParamsUpdate, Slot);
+import PParams(Coin, Epoch, PParamsUpdate);
 import Delegation(DCert);
 
 {-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request implements a basic package system for FineTypes.

- [x] `spec.md` and `howto.md` give a brief overview of planned functionality.
- [x] `Package` represents a mapping from module names to modules.
- [x] `PackageDescription` can be parsed from a file that begins with `package … where …`.
- [x] `PackageDescription` can be compiled to a `Package`.
- [x] A file `Shelley.fine` provides a package description for the Shelley ledger specifications. Found a broken import in `Tx` and `Block`. 😊 

### Comments

* "Physical identities" for packages have not been implemented yet. This can lead to problems when writing more complicated packages that involve diamond dependencies or multiple dependencies on the same modules. This will be fixed later.
* Eventually, the package system will be a stripped-down dialect of [Backpack'14][backpack]. We keep the concepts of modules, signatures, and packages, but we disallow "merging" of signatures and packages, as this

    * simplifies the implementation dramatically
    * still allows us to write interested static checks by putting them into separate packages, and
    * does not preclude allowing merges later.

  [backpack]: https://plv.mpi-sws.org/backpack/

### Issue number

ADP-3167