### PR TITLE
[ADP-3182] report constraints in json schema

### DIFF
--- a/lib/fine-types/fine-types.cabal
+++ b/lib/fine-types/fine-types.cabal
@@ -105,6 +105,7 @@ test-suite unit
   build-depends:
     , aeson
     , base
+    , bytestring
     , containers
     , deepseq
     , filepath

--- a/lib/fine-types/src/Language/FineTypes/Export/Haskell/Typ.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/Haskell/Typ.hs
@@ -201,7 +201,7 @@ typeFromTyp = go
         error "Nested Product is not supported by Haskell"
     go (SumN _) =
         error "Nested Sum is not supported by Haskell"
-    go (Constrained typ _) =
+    go (Constrained _ typ _) =
         -- FIXME: Emit a warning.
         -- TODO: Add Liquid Haskell support for top-level definitions? 😲
         -- Currently no good representation for comments / Liquid Haskell

--- a/lib/fine-types/src/Language/FineTypes/Export/OpenAPI/Schema.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/OpenAPI/Schema.hs
@@ -104,7 +104,7 @@ supportsJSON =
     isSupportedTyp = everything (&&) isSupported
     isSupported (Two fun _ _) =
         fun `notElem` [PartialFunction, FiniteSupport]
-    isSupported (Constrained _ _) =
+    isSupported Constrained{} =
         False
     isSupported _ = True
 
@@ -203,7 +203,7 @@ schemaFromTyp = go
         schemaFromProductN fields
     go (SumN constructors) =
         schemaFromSumN constructors
-    go (Constrained _ _) =
+    go Constrained{} =
         error "ConstrainedTyp is not supported by JSON schema"
 
 -- | Map a record type to a JSON schema.

--- a/lib/fine-types/src/Language/FineTypes/Export/OpenAPI/Value/ToJSON.hs
+++ b/lib/fine-types/src/Language/FineTypes/Export/OpenAPI/Value/ToJSON.hs
@@ -60,6 +60,7 @@ jsonFromValue :: Typ -> Value -> JS.Value
 jsonFromValue = go
   where
     go :: Typ -> Value -> JS.Value
+    go (Typ.Constrained _ typ _) value = go typ value
     go (Typ.Two Typ.Product2 ta tb) (Product [a, b]) =
         JS.object ["0" .= go ta a, "1" .= go tb b]
     go (Typ.ProductN fields) (Product ps) =

--- a/lib/fine-types/src/Language/FineTypes/Parser.hs
+++ b/lib/fine-types/src/Language/FineTypes/Parser.hs
@@ -40,6 +40,7 @@ import Language.FineTypes.Typ
     , Typ (..)
     , TypConst (..)
     , TypName
+    , VarName
     )
 import Text.Megaparsec
     ( ParseErrorBundle
@@ -169,11 +170,11 @@ mkDocumentedDeclaration doc1 name (DocumentedTyp typ fs cs) doc2 =
 
 constrained :: Parser Typ
 constrained = braces $ do
-    _ <- varName
+    v <- varName
     _ <- symbol ":"
     typ <- zeroVar
     _ <- symbol "|"
-    Constrained typ <$> constraint
+    Constrained v typ <$> constraint
 
 abstract :: Parser Typ
 abstract = Abstract <$ symbol "_"
@@ -378,8 +379,6 @@ fieldName :: Parser FieldName
 fieldName =
     L.lexeme space
         $ many (C.alphaNumChar <|> satisfy (`elem` "_^-"))
-
-type VarName = String
 
 varName :: Parser VarName
 varName =

--- a/lib/fine-types/src/Language/FineTypes/Typ/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Typ/Gen.hs
@@ -143,7 +143,8 @@ genConstrainedTyp mode = do
     constraintDepth <- choose (1, 2)
     c <- genConstraint constraintDepth
     typ <- genTyp'
-    pure $ Constrained typ c
+    v <- genName
+    pure $ Constrained v typ c
   where
     complete = onComplete mode
     always = id
@@ -225,10 +226,10 @@ shrinkTyp = \case
             <> (SumN <$> shrinkList shrinkNamed constructors)
     Var _ -> []
     Abstract -> []
-    Constrained typ c ->
+    Constrained v typ c ->
         [typ]
-            <> [Constrained typ' c | typ' <- shrinkTyp typ]
-            <> [Constrained typ c' | c' <- shrinkConstraint c]
+            <> [Constrained v typ' c | typ' <- shrinkTyp typ]
+            <> [Constrained v typ c' | c' <- shrinkConstraint c]
 
 shrinkNamed :: (t, Typ) -> [(t, Typ)]
 shrinkNamed (f, t) = (f,) <$> shrinkTyp t

--- a/lib/fine-types/src/Language/FineTypes/Typ/PrettyPrinter.hs
+++ b/lib/fine-types/src/Language/FineTypes/Typ/PrettyPrinter.hs
@@ -29,6 +29,7 @@ import Language.FineTypes.Typ
     , Typ (..)
     , TypConst (..)
     , TypName
+    , VarName
     )
 import Prettyprinter
     ( Doc
@@ -58,7 +59,7 @@ requireParens = \case
     SumN _ -> False
     Var _ -> False
     Abstract -> False
-    Constrained _ _ -> False
+    Constrained{} -> False
 
 parens :: Doc ann -> Doc ann
 parens doc = encloseSep "(" ")" " " [doc]
@@ -69,12 +70,15 @@ withParens f x = if requireParens x then parens (f x) else f x
 prettyConstrainedTyp
     :: QueryDocumentation
     -> TypName
+    -> VarName
     -> Typ
     -> Constraint
     -> Doc ann
-prettyConstrainedTyp docs typname typ [] = prettyTyp docs typname typ
-prettyConstrainedTyp docs typname typ constraint =
-    "{ x :"
+prettyConstrainedTyp docs typname _v typ [] = prettyTyp docs typname typ
+prettyConstrainedTyp docs typname v typ constraint =
+    "{"
+        <+> pretty v
+        <+> ":"
         <+> prettyTyp docs typname typ
         <+> prettyText "|"
         <+> prettyConstraint constraint
@@ -154,7 +158,7 @@ prettyTyp docs typname = \case
     SumN constructors -> prettySumN docs typname constructors
     Var name -> pretty name
     Abstract -> prettyText "_"
-    Constrained typ c -> prettyConstrainedTyp docs typname typ c
+    Constrained v typ c -> prettyConstrainedTyp docs typname v typ c
   where
     prettyTyp' = prettyTyp docs typname
 

--- a/lib/fine-types/src/Language/FineTypes/Value.hs
+++ b/lib/fine-types/src/Language/FineTypes/Value.hs
@@ -76,6 +76,8 @@ newtype TwoF a b
 
 -- | Check whether a 'Value' inhabits the given 'Typ'.
 hasTyp :: Value -> Typ -> Bool
+hasTyp z (Typ.Constrained _ t _) =
+    z `hasTyp` t
 hasTyp (Zero a) (Typ.Zero b) =
     typOf0 a == b
 hasTyp (Zero _) _ =

--- a/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
+++ b/lib/fine-types/src/Language/FineTypes/Value/Gen.hs
@@ -119,6 +119,7 @@ genTypValue typ =
             ix <- lift $ choose (0, length constructors - 1)
             let (_cn, typ') = constructors !! ix
             Sum ix <$> exceptGenValue typ'
+        Typ.Constrained _ typ' _ -> genTypValue typ'
         typ' -> pure $ Left typ'
 
 genTypAndValue

--- a/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/SchemaSpec.hs
+++ b/lib/fine-types/test/Language/FineTypes/Export/OpenAPI/SchemaSpec.hs
@@ -28,7 +28,7 @@ import Language.FineTypes.Typ
     )
 import Language.FineTypes.Typ.Gen
     ( Mode (Concrete)
-    , WithConstraints (WithoutConstraints)
+    , WithConstraints (..)
     )
 import Language.FineTypes.Value.Gen (genTypAndValue)
 import Test.Hspec
@@ -63,7 +63,7 @@ spec = do
                 ( genTypAndValue
                     (const True)
                     unsupported
-                    WithoutConstraints
+                    WithConstraints
                     Concrete
                     6
                 )

--- a/lib/fine-types/test/data/JsonUTxO.fine
+++ b/lib/fine-types/test/data/JsonUTxO.fine
@@ -20,7 +20,7 @@ DataHash = Bytes;
 Quantity = ℤ;
 
 Value =
-  { ada    : Quantity
+  { ada    : {x : Quantity | x > 0}
   , assets : Asset*
   };
 


### PR DESCRIPTION
- [x] extend Constrained constructor to hold  the var name.
- [x] support Constrained typs in json schema rendering
- [x]  fix tests to reflect the new support
ADP-3182