### PR TITLE
[ADP-3234] Add Agda environment to `nix develop`

### DIFF
--- a/.buildkite/check-agda.sh
+++ b/.buildkite/check-agda.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd .buildkite/check-agda
+
+echo "### Checking AGDA_DIR"
+echo AGDA_DIR=$AGDA_DIR
+
+echo "### Checking Agda"
+agda --version
+agda \
+    --no-default-libraries \
+    --local-interfaces \
+    Everything.agda && rm Everything.agdai
+
+echo "### Checking agda2hs"
+agda2hs --version
+agda2hs \
+    --no-default-libraries \
+    --local-interfaces \
+    Everything.agda && rm Everything.hs Everything.agdai

--- a/.buildkite/check-agda/Everything.agda
+++ b/.buildkite/check-agda/Everything.agda
@@ -1,0 +1,7 @@
+module Everything where
+
+-- standard-library
+open import Data.Sum using (_⊎_; inj₁; inj₂)
+
+-- agda2hs
+open import Haskell.Prelude

--- a/.buildkite/check-agda/check.agda-lib
+++ b/.buildkite/check-agda/check.agda-lib
@@ -1,0 +1,6 @@
+name: check
+include: .
+depend:
+  standard-library
+  agda2hs
+flags: -W noUnsupportedIndexedMatch --erasure

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,10 +47,20 @@ steps:
       system: ${linux}
     env:
       TMPDIR: "/cache"
+
   - label: "Check cardano-ledger-specs"
     depends_on: linux-nix
     command: |
       ${nix} --command bash -c scripts/cardano-ledger-specs.sh
+    agents:
+      system: ${linux}
+    env:
+      TMPDIR: "/cache"
+
+  - label: "Check agda2hs"
+    depends_on: linux-nix
+    command: |
+      ${nix} --command bash -c '.buildkite/check-agda.sh'
     agents:
       system: ${linux}
     env:

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 -- repeating the index-state for hackage to work around hackage.nix parsing limitation
 
 index-state:
-  , hackage.haskell.org 2023-08-22T11:08:41Z
+  , hackage.haskell.org 2023-11-26T21:52:49Z
   , cardano-haskell-packages 2023-06-05T06:39:32Z
 
 packages:

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "CHaP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1694418828,
-        "narHash": "sha256-AvhT3sIszBOoKI+HiSeoRS8We3HlngP2sPzLgIYx4Gg=",
-        "owner": "input-output-hk",
-        "repo": "cardano-haskell-packages",
-        "rev": "43bb9380c49d8e65169d83ba3e1957ef01f97617",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "repo",
-        "repo": "cardano-haskell-packages",
-        "type": "github"
-      }
-    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -120,22 +103,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1672831974,
         "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
@@ -186,14 +153,51 @@
         "type": "github"
       }
     },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697054644,
+        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "ref": "refs/heads/master",
+        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
+        "revCount": 62040,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1694391774,
-        "narHash": "sha256-FvGv9drim3WIgQaq5c7IkKxWDTWtdd85Vh5eq4UBdoM=",
+        "lastModified": 1701044613,
+        "narHash": "sha256-OdiZwE4on2vev78bykz4pm9zsapWrzdPcxvrAki48vI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "313a97ec97db179956f1a9eebf843aa23f39a7c7",
+        "rev": "7fa495d9f3beec14b32ea20f3388516aa2e64481",
         "type": "github"
       },
       "original": {
@@ -209,12 +213,16 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc98X": "ghc98X",
+        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -233,11 +241,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1694393385,
-        "narHash": "sha256-iUE7ocxhaklvAsZqRJ/F3NzcS/vzPvyknD8M5GB9CiU=",
+        "lastModified": 1701053834,
+        "narHash": "sha256-4sH4//POARjeKJv1mu8aU4W4A28GYqrj9KB3PqusHis=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "f398fc55fb8fe16501ff9c9e06d2c88434c4b2c2",
+        "rev": "7c491c55157208575c70c7b8434e9d4a1cf173a6",
         "type": "github"
       },
       "original": {
@@ -297,6 +305,40 @@
         "type": "github"
       }
     },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696939266,
+        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -344,11 +386,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1693968598,
-        "narHash": "sha256-2wFadXHMgNYrF7N6jndfp3Ywm2G0r+QTPifrlzugkjo=",
+        "lastModified": 1698999258,
+        "narHash": "sha256-42D1BMbdyZD+lT+pWUzb5zDQyasNbMJtH/7stuPuPfE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "7d738e59d276336d1e02447e27b0373164d3bc88",
+        "rev": "73dc2bb45af6f20cfe1d962f1334eed5e84ae764",
         "type": "github"
       },
       "original": {
@@ -360,11 +402,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -509,11 +551,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
@@ -541,11 +583,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -590,8 +632,6 @@
     },
     "root": {
       "inputs": {
-        "CHaP": "CHaP",
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
@@ -638,11 +678,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1694304585,
-        "narHash": "sha256-vs31FW287tu1z0Wtq0C6+K85wD36sRGeAeFuPSFZ7PY=",
+        "lastModified": 1701043780,
+        "narHash": "sha256-d5CYT7WGEaL6IFNmUg4JUb+onxI/tO1qgHs/TCIKB3A=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "26e9f75a4775f37ef73ffdde706ca65a2be2151f",
+        "rev": "cb49435b81adf0549589c51f39b5b38b4369f106",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,82 @@
         "type": "github"
       }
     },
+    "agda": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "agda-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696540558,
+        "narHash": "sha256-fqYyjgOFQrU4ryGcLyz5gMYMdPk1P24ra7kQiUrbilg=",
+        "owner": "agda",
+        "repo": "agda",
+        "rev": "f42acb696e43d382639f04f869e9a99ab36a91c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.6.4",
+        "repo": "agda",
+        "type": "github"
+      }
+    },
+    "agda-stdlib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700966885,
+        "narHash": "sha256-fGgOAvTWqVWE2kap2WQtsAwMSJDi3fK/V3lJ6ttDcGo=",
+        "owner": "agda",
+        "repo": "agda-stdlib",
+        "rev": "53c36cd0e0d6dd361e50757d90fc887375dec523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.0-rc2",
+        "repo": "agda-stdlib",
+        "type": "github"
+      }
+    },
+    "agda-tools": {
+      "inputs": {
+        "agda": "agda",
+        "agda-stdlib": "agda-stdlib",
+        "agda2hs": "agda2hs",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-c7DTnv5oHIO3+c/dqkVwuuJgogYGrDyyHGYXZSlRFK8=",
+        "path": "./nix/agda",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix/agda",
+        "type": "path"
+      }
+    },
+    "agda2hs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701096344,
+        "narHash": "sha256-quN9bcMH6+qyf7jlG/Q2ICIk0YimgNUBQ0CzyCrW4fE=",
+        "owner": "agda",
+        "repo": "agda2hs",
+        "rev": "e4bca5833042f7e18dd278e3a9eaa33fdfc8792d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "e4bca5833042f7e18dd278e3a9eaa33fdfc8792d",
+        "repo": "agda2hs",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -118,8 +194,42 @@
       }
     },
     "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681378341,
@@ -193,11 +303,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1701044613,
-        "narHash": "sha256-OdiZwE4on2vev78bykz4pm9zsapWrzdPcxvrAki48vI=",
+        "lastModified": 1701130974,
+        "narHash": "sha256-0ykM3chRG8TXHhfEytU1IerNq5vN5rluaOnLNCJUZ6s=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7fa495d9f3beec14b32ea20f3388516aa2e64481",
+        "rev": "618294813c33cc6c8b98c1ec5570bc48864b13ec",
         "type": "github"
       },
       "original": {
@@ -241,11 +351,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1701053834,
-        "narHash": "sha256-4sH4//POARjeKJv1mu8aU4W4A28GYqrj9KB3PqusHis=",
+        "lastModified": 1701132614,
+        "narHash": "sha256-xQd40g4P4NN38i2Z6esGpwiHp256H60uGqSm5Y4+WiA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7c491c55157208575c70c7b8434e9d4a1cf173a6",
+        "rev": "c713f9448947520e65974f942c0d906202ffdf7a",
         "type": "github"
       },
       "original": {
@@ -381,7 +491,9 @@
     "iohkNix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -435,7 +547,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -455,16 +567,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1701445595,
+        "narHash": "sha256-TnweUF/DxQw7x01oJCR7Z842PmOXrst99K4RLTQ035Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "cae1e33e8c0a36e50d67f1b604b74825f6b35ad5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -599,16 +710,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -632,7 +743,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "agda-tools": "agda-tools",
+        "flake-utils": "flake-utils_3",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [
@@ -678,11 +790,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1701043780,
-        "narHash": "sha256-d5CYT7WGEaL6IFNmUg4JUb+onxI/tO1qgHs/TCIKB3A=",
+        "lastModified": 1701130167,
+        "narHash": "sha256-Mdzljtmfe6lg8lo7BAMXPRay0fH17MVoBQJBPzt3s+w=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "cb49435b81adf0549589c51f39b5b38b4369f106",
+        "rev": "4396102706df8636afae08806984e03f4afd381e",
         "type": "github"
       },
       "original": {
@@ -692,6 +804,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,6 @@
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
-
-    CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
-    CHaP.flake = false;
-
-    # non-flake nix compatibility
-    flake-compat.url = "github:edolstra/flake-compat";
-    flake-compat.flake = false;
   };
 
   outputs = inputs:
@@ -42,15 +35,6 @@
           name = "fine-type";
           compiler-nix-name = "ghc928";
 
-          # CHaP input map, so we can find CHaP packages (needs to be more
-          # recent than the index-state we set!). Can be updated with
-          #
-          #  nix flake lock --update-input CHaP
-          #
-          inputMap = {
-            "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
-          };
-
           # tools we want in our shell
           shell.tools = {
             cabal = "3.10.1.0";
@@ -67,51 +51,12 @@
             gitAndTools.git
           ];
           shell.withHoogle = true;
-
-          # package customizations as needed. Where cabal.project is not
-          # specific enough, or doesn't allow setting these.
-          modules = [
-            ({pkgs, ...}: {
-              # Packages we wish to ignore version bounds of.
-              # This is similar to jailbreakCabal, however it
-              # does not require any messing with cabal files.
-              packages.katip.doExactConfig = true;
-
-              # split data output for ekg to reduce closure size
-              packages.ekg.components.library.enableSeparateDataOutput = true;
-              packages.cardano-binary.configureFlags = [ "--ghc-option=-Werror" ];
-              packages.cardano-crypto-class.configureFlags = [ "--ghc-option=-Werror" ];
-              packages.slotting.configureFlags = [ "--ghc-option=-Werror" ];
-              enableLibraryProfiling = profiling;
-            })
-            ({pkgs, ...}: with pkgs; nixpkgs.lib.mkIf stdenv.hostPlatform.isWindows {
-              packages.text.flags.simdutf = false;
-              # Disable cabal-doctest tests by turning off custom setups
-              packages.comonad.package.buildType = lib.mkForce "Simple";
-              packages.distributive.package.buildType = lib.mkForce "Simple";
-              packages.lens.package.buildType = lib.mkForce "Simple";
-              packages.nonempty-vector.package.buildType = lib.mkForce "Simple";
-              packages.semigroupoids.package.buildType = lib.mkForce "Simple";
-
-              # Make sure we use a buildPackages version of happy
-              # packages.pretty-show.components.library.build-tools = [ (pkgsBuildBuild.haskell-nix.tool compiler-nix-name "happy" "1.20.1.1") ];
-
-              # Remove hsc2hs build-tool dependencies (suitable version will be available as part of the ghc derivation)
-              packages.Win32.components.library.build-tools = lib.mkForce [];
-              packages.terminal-size.components.library.build-tools = lib.mkForce [];
-              packages.network.components.library.build-tools = lib.mkForce [];
-            })
-          ];
         }).flake (
           # we also want cross compilation to windows.
           nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
           crossPlatforms = p: [p.mingwW64];
         });
-      in nixpkgs.lib.recursiveUpdate flake {
-        # add a required job, that's basically all hydraJobs.
-        # hydraJobs = nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
-        #  { ciJobs = flake.hydraJobs; };
-      }
+      in flake
     );
 
   nixConfig = {

--- a/lib/deposit-wallet-mock/src/Servant/FineTypes.hs
+++ b/lib/deposit-wallet-mock/src/Servant/FineTypes.hs
@@ -28,9 +28,6 @@ import Servant.API
     , MimeRender (..)
     , MimeUnrender (..)
     )
-import Servant.API.ContentTypes
-    ( eitherDecodeLenient
-    )
 
 import Data.Aeson as JS
 
@@ -52,6 +49,6 @@ instance forall a. ToValue a => MimeRender FineJSON a where
 
 instance forall a. FromValue a => MimeUnrender FineJSON a where
     mimeUnrender _ bs =
-        fmap fromValue . valueFromJson typ =<< eitherDecodeLenient bs
+        fmap fromValue . valueFromJson typ =<< JS.eitherDecode bs
       where
         typ = toTyp (Proxy :: Proxy a)

--- a/nix/agda/Everything.agda
+++ b/nix/agda/Everything.agda
@@ -1,0 +1,14 @@
+module Everything where
+
+import Haskell.Control.Monad
+
+import Haskell.Law
+import Haskell.Law.Monad
+import Haskell.Law.Applicative
+import Haskell.Law.Bool
+import Haskell.Law.Eq
+import Haskell.Law.Equality
+import Haskell.Law.Functor
+import Haskell.Law.List
+
+import Haskell.Prelude

--- a/nix/agda/flake.lock
+++ b/nix/agda/flake.lock
@@ -1,0 +1,135 @@
+{
+  "nodes": {
+    "agda": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696540558,
+        "narHash": "sha256-fqYyjgOFQrU4ryGcLyz5gMYMdPk1P24ra7kQiUrbilg=",
+        "owner": "agda",
+        "repo": "agda",
+        "rev": "f42acb696e43d382639f04f869e9a99ab36a91c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.6.4",
+        "repo": "agda",
+        "type": "github"
+      }
+    },
+    "agda-stdlib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700966885,
+        "narHash": "sha256-fGgOAvTWqVWE2kap2WQtsAwMSJDi3fK/V3lJ6ttDcGo=",
+        "owner": "agda",
+        "repo": "agda-stdlib",
+        "rev": "53c36cd0e0d6dd361e50757d90fc887375dec523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.0-rc2",
+        "repo": "agda-stdlib",
+        "type": "github"
+      }
+    },
+    "agda2hs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701096344,
+        "narHash": "sha256-quN9bcMH6+qyf7jlG/Q2ICIk0YimgNUBQ0CzyCrW4fE=",
+        "owner": "agda",
+        "repo": "agda2hs",
+        "rev": "e4bca5833042f7e18dd278e3a9eaa33fdfc8792d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "e4bca5833042f7e18dd278e3a9eaa33fdfc8792d",
+        "repo": "agda2hs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701445595,
+        "narHash": "sha256-TnweUF/DxQw7x01oJCR7Z842PmOXrst99K4RLTQ035Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cae1e33e8c0a36e50d67f1b604b74825f6b35ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agda": "agda",
+        "agda-stdlib": "agda-stdlib",
+        "agda2hs": "agda2hs",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/agda/flake.nix
+++ b/nix/agda/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = ''
+    Agda tools for Haskell
+    — agda, agda2hs, and suitable libraries
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    
+    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+
+    agda.url = "github:agda/agda?ref=v2.6.4";
+    agda.inputs.nixpkgs.follows = "nixpkgs";
+
+    agda2hs = {
+      url = "github:agda/agda2hs?ref=e4bca5833042f7e18dd278e3a9eaa33fdfc8792d";
+      flake = false;
+    };
+    agda-stdlib = {
+      url = "github:agda/agda-stdlib?ref=v2.0-rc2";
+      flake = false;
+    };
+  };
+
+  outputs = inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+       ]; in
+    inputs.flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        # ###########################################
+        # Imports
+
+        # Packages with patches
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+        agda2hs-patched = import ./patch-agda2hs.nix {
+          inherit pkgs;
+          agda2hs-unpatched = inputs.agda2hs;
+        };
+
+        # Library
+        lib = import ./lib.nix {
+          inherit (pkgs) lib writeText runCommand; 
+        };
+        
+        # ###########################################
+        # Helpers
+
+        # Specific agda packages that we want to depend on.
+        mkAgdaPackages = p: [
+          (p.standard-library.overrideAttrs (oldAttrs: {
+            version = "v2.0-rc2";
+            src = inputs.agda-stdlib.outPath;
+          }))
+          (p.mkDerivation {
+            pname = "agda2hs";
+            version = "1.2";
+            meta = "Agda-to-Haskell transpiler library";
+            src = agda2hs-patched;
+          })
+        ];
+
+      in rec {
+        packages = {
+          agda = pkgs.agda.withPackages mkAgdaPackages;
+          agda2hs = pkgs.haskell.lib.doJailbreak (
+            pkgs.haskellPackages.callCabal2nix "agda2hs" inputs.agda2hs.outPath {}
+          );
+          agda-dir =
+            lib.agdaDirFromPackages (mkAgdaPackages pkgs.agdaPackages);
+        };
+
+        apps = {
+          agda2hs = inputs.flake-utils.lib.mkApp {
+            drv = packages.agda2hs;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            packages.agda
+            packages.agda2hs
+          ];
+          shellHook = ''
+            export AGDA_DIR=${packages.agda-dir.outPath}
+          '';
+        };
+      }
+    ) // {
+      overlay = inputs.agda.overlay;
+    };
+}

--- a/nix/agda/lib.nix
+++ b/nix/agda/lib.nix
@@ -1,0 +1,27 @@
+# Library of Nix functions
+
+{ lib, runCommand, writeText } :
+
+{
+  # agdaDirFromPackages : List AgdaPackage -> Derivation
+  #
+  # Collate a list of packages into a `libraries` file.
+  # Returns a derivation for a directory that can be used as AGDA_DIR.
+  # 
+  # Inspired by
+  # https://github.com/NixOS/nixpkgs/blob/5b5005879388f32bb639cb389635a99cde4ea000/pkgs/build-support/agda/default.nix#L8-L36
+  agdaDirFromPackages = pkgs :
+    let
+      libraries-file = writeText "libraries" ''
+        ${(lib.strings.concatMapStringsSep "\n" (p: "${p}/${p.libraryFile}") pkgs)}
+      '';
+      pname = "agda-libraries";
+      version = "1.0";
+    in
+      runCommand "${pname}-${version}" {
+        inherit pname version;
+      } ''
+        mkdir -p $out
+        cp ${libraries-file} $out/libraries
+      '';
+}

--- a/nix/agda/patch-agda2hs.nix
+++ b/nix/agda/patch-agda2hs.nix
@@ -1,0 +1,7 @@
+{ pkgs, agda2hs-unpatched }:
+
+pkgs.runCommandLocal "agda2hs-patched" {} ''
+  cp -r ${agda2hs-unpatched.outPath} $out
+  chmod -R +w $out
+  cat ${./Everything.agda} >$out/Everything.agda
+''


### PR DESCRIPTION
This pull request adds the following to the `nix develop` shell:

* `Agda` version 2.6.4
   * Including libraries
* `agda2hs` version 1.2
* Test that the above work as intended

### Comments

This pull request also applies an unrelated fix to `deposit-wallet-mock` that may have been introduced by updating the hackage index.