### PR TITLE
[ADP-3134] Update to GHC 9.6.4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,6 +47,7 @@ steps:
       system: ${linux}
     env:
       TMPDIR: "/cache"
+
   - label: "Check cardano-ledger-specs"
     depends_on: linux-nix
     command: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,19 +26,19 @@ jobs:
           - macOS-latest
           - windows-latest
         cabal:
-          - 3.8.1.0
+          - latest
         ghc:
           - 8.10.7
           - 9.0.2
           - 9.2.8
-          - 9.4.5
-          - 9.6.2
+          - 9.4.8
+          - 9.6.4
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Environment
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -83,8 +83,8 @@ jobs:
           --builddir=${{ env.cabal-build-dir }}
           --enable-tests
           --enable-benchmarks
-          --ghc-options=-Werror
           --ghc-options=-Wall
+          --ghc-options=-Werror
 
       - name: Test
         run: >
@@ -110,7 +110,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.6.2'
+            && matrix.ghc == '9.6.4'
         run: >
           mv ${{ env.cabal-build-dir }}/build/*/*/*/doc/html/* gh-pages
 
@@ -120,7 +120,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.6.2'
+            && matrix.ghc == '9.6.4'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,4 @@
--- repeating the index-state for hackage to work around hackage.nix parsing limitation
-
-index-state:
-  , hackage.haskell.org 2023-08-22T11:08:41Z
-  , cardano-haskell-packages 2023-06-05T06:39:32Z
+index-state: 2024-03-11T12:58:06Z
 
 packages:
     lib/fine-types/

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "CHaP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1694418828,
-        "narHash": "sha256-AvhT3sIszBOoKI+HiSeoRS8We3HlngP2sPzLgIYx4Gg=",
-        "owner": "input-output-hk",
-        "repo": "cardano-haskell-packages",
-        "rev": "43bb9380c49d8e65169d83ba3e1957ef01f97617",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "repo",
-        "repo": "cardano-haskell-packages",
-        "type": "github"
-      }
-    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -36,17 +19,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -120,22 +103,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1672831974,
         "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
         "owner": "input-output-hk",
@@ -186,14 +153,51 @@
         "type": "github"
       }
     },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701580282,
+        "narHash": "sha256-drA01r3JrXnkKyzI+owMZGxX0JameMzjK0W5jJE/+V4=",
+        "ref": "refs/heads/master",
+        "rev": "f5eb0f2982e9cf27515e892c4bdf634bcfb28459",
+        "revCount": 62197,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1694391774,
-        "narHash": "sha256-FvGv9drim3WIgQaq5c7IkKxWDTWtdd85Vh5eq4UBdoM=",
+        "lastModified": 1710116585,
+        "narHash": "sha256-pqZzSf53YQsH71nh/nKHr+sOAo+85Uewf0NzLrbcfAI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "313a97ec97db179956f1a9eebf843aa23f39a7c7",
+        "rev": "9a132505dd7e8e68f6303a74b884e3f5bdb16260",
         "type": "github"
       },
       "original": {
@@ -209,15 +213,22 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc98X": "ghc98X",
+        "ghc99": "ghc99",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
+        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -228,21 +239,39 @@
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1694393385,
-        "narHash": "sha256-iUE7ocxhaklvAsZqRJ/F3NzcS/vzPvyknD8M5GB9CiU=",
+        "lastModified": 1710118177,
+        "narHash": "sha256-FWb3R+EiQYRjheFGebkYT0sMRUcleu7BhSUKPQCB4RQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "f398fc55fb8fe16501ff9c9e06d2c88434c4b2c2",
+        "rev": "79936c3d39c48b335d87e29cfef3504fbfab1af0",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1707224159,
+        "narHash": "sha256-1quJwNdQGL/pSk0tYZ/p8ye50HN4ClWlrFf2FWnt0wA=",
+        "owner": "cardano-scaling",
+        "repo": "haskell-language-server",
+        "rev": "1170a7c3134fe7591c3e890e23521fe838ac2abe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cardano-scaling",
+        "ref": "2.6-patched",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -297,6 +326,74 @@
         "type": "github"
       }
     },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -344,11 +441,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1693968598,
-        "narHash": "sha256-2wFadXHMgNYrF7N6jndfp3Ywm2G0r+QTPifrlzugkjo=",
+        "lastModified": 1709083850,
+        "narHash": "sha256-6DQ89ktt8rRVV1pXEyX2JwPjaqS0mQkelkmJmka04rg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "7d738e59d276336d1e02447e27b0373164d3bc88",
+        "rev": "1c793a53ac0bd99b795c2180eb23d37e8389a74b",
         "type": "github"
       },
       "original": {
@@ -360,11 +457,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -408,6 +505,23 @@
         "owner": "NixOS",
         "ref": "2.11.0",
         "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-tools-static": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1706266250,
+        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
+        "owner": "input-output-hk",
+        "repo": "haskell-nix-example",
+        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "haskell-nix-example",
         "type": "github"
       }
     },
@@ -509,16 +623,32 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -541,17 +671,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -590,10 +720,9 @@
     },
     "root": {
       "inputs": {
-        "CHaP": "CHaP",
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
+        "hls": "hls",
         "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
@@ -638,11 +767,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1694304585,
-        "narHash": "sha256-vs31FW287tu1z0Wtq0C6+K85wD36sRGeAeFuPSFZ7PY=",
+        "lastModified": 1709942930,
+        "narHash": "sha256-lyso6y6hyYOjhvM7GEIAb2GQiPt30CXGlMRjinqM/Ps=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "26e9f75a4775f37ef73ffdde706ca65a2be2151f",
+        "rev": "90527efba6389051effb4839def962c5a5b4af92",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,10 @@
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
-
-    CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
-    CHaP.flake = false;
-
-    # non-flake nix compatibility
-    flake-compat.url = "github:edolstra/flake-compat";
-    flake-compat.flake = false;
+    hls = {
+      url = "github:cardano-scaling/haskell-language-server?ref=2.6-patched";
+      flake = false;
+    };
   };
 
   outputs = inputs:
@@ -40,23 +37,11 @@
         flake = (nixpkgs.haskell-nix.cabalProject' rec {
           src = ./.;
           name = "fine-type";
-          compiler-nix-name = "ghc928";
-
-          # CHaP input map, so we can find CHaP packages (needs to be more
-          # recent than the index-state we set!). Can be updated with
-          #
-          #  nix flake lock --update-input CHaP
-          #
-          inputMap = {
-            "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
-          };
+          compiler-nix-name = "ghc964";
 
           # tools we want in our shell
           shell.tools = {
             cabal = "3.10.1.0";
-            ghcid = "0.8.8";
-            haskell-language-server = "latest";
-            hlint = {};
             fourmolu = "0.13.1.0";
           };
           # Now we use pkgsBuildBuild, to make sure that even in the cross
@@ -65,53 +50,21 @@
           shell.buildInputs = with nixpkgs.pkgsBuildBuild; [
             just
             gitAndTools.git
+            haskellPackages.ghcid
+            haskellPackages.hlint
+
+            (haskell-nix.tool "ghc964" "haskell-language-server" ({pkgs, ...}: rec {
+            # Use the github source of HLS that is tested with haskell.nix CI
+            src = inputs.hls;
+            }))
           ];
           shell.withHoogle = true;
-
-          # package customizations as needed. Where cabal.project is not
-          # specific enough, or doesn't allow setting these.
-          modules = [
-            ({pkgs, ...}: {
-              # Packages we wish to ignore version bounds of.
-              # This is similar to jailbreakCabal, however it
-              # does not require any messing with cabal files.
-              packages.katip.doExactConfig = true;
-
-              # split data output for ekg to reduce closure size
-              packages.ekg.components.library.enableSeparateDataOutput = true;
-              packages.cardano-binary.configureFlags = [ "--ghc-option=-Werror" ];
-              packages.cardano-crypto-class.configureFlags = [ "--ghc-option=-Werror" ];
-              packages.slotting.configureFlags = [ "--ghc-option=-Werror" ];
-              enableLibraryProfiling = profiling;
-            })
-            ({pkgs, ...}: with pkgs; nixpkgs.lib.mkIf stdenv.hostPlatform.isWindows {
-              packages.text.flags.simdutf = false;
-              # Disable cabal-doctest tests by turning off custom setups
-              packages.comonad.package.buildType = lib.mkForce "Simple";
-              packages.distributive.package.buildType = lib.mkForce "Simple";
-              packages.lens.package.buildType = lib.mkForce "Simple";
-              packages.nonempty-vector.package.buildType = lib.mkForce "Simple";
-              packages.semigroupoids.package.buildType = lib.mkForce "Simple";
-
-              # Make sure we use a buildPackages version of happy
-              # packages.pretty-show.components.library.build-tools = [ (pkgsBuildBuild.haskell-nix.tool compiler-nix-name "happy" "1.20.1.1") ];
-
-              # Remove hsc2hs build-tool dependencies (suitable version will be available as part of the ghc derivation)
-              packages.Win32.components.library.build-tools = lib.mkForce [];
-              packages.terminal-size.components.library.build-tools = lib.mkForce [];
-              packages.network.components.library.build-tools = lib.mkForce [];
-            })
-          ];
         }).flake (
           # we also want cross compilation to windows.
           nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
           crossPlatforms = p: [p.mingwW64];
         });
-      in nixpkgs.lib.recursiveUpdate flake {
-        # add a required job, that's basically all hydraJobs.
-        # hydraJobs = nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
-        #  { ciJobs = flake.hydraJobs; };
-      }
+      in flake
     );
 
   nixConfig = {

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ set positional-arguments
 
 set export
 
-LC_ALL := "C.UTF-8"
+LC_CTYPE := "UTF-8"
 
 seed := "0"
 

--- a/lib/deposit-wallet-mock/src/Servant/FineTypes.hs
+++ b/lib/deposit-wallet-mock/src/Servant/FineTypes.hs
@@ -28,9 +28,6 @@ import Servant.API
     , MimeRender (..)
     , MimeUnrender (..)
     )
-import Servant.API.ContentTypes
-    ( eitherDecodeLenient
-    )
 
 import Data.Aeson as JS
 
@@ -52,6 +49,6 @@ instance forall a. ToValue a => MimeRender FineJSON a where
 
 instance forall a. FromValue a => MimeUnrender FineJSON a where
     mimeUnrender _ bs =
-        fmap fromValue . valueFromJson typ =<< eitherDecodeLenient bs
+        fmap fromValue . valueFromJson typ =<< JS.eitherDecode bs
       where
         typ = toTyp (Proxy :: Proxy a)


### PR DESCRIPTION
This pull request updates to GHC 9.6.4 and performs related tasks, such as simplifying `flake.nix`.

### Issue number

ADP-3134