### PR TITLE
[ADP-3191] Add `Agda` and `agda2hs` to `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,87 @@
         "type": "github"
       }
     },
+    "agda": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "agda-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701366566,
+        "narHash": "sha256-B8Jmjld0gGbkVO08GsovVqrUXCs8VfJ8UdM3sjHnzgM=",
+        "owner": "agda",
+        "repo": "agda",
+        "rev": "4293e0a94d15acac915ab9088b2ec028f78d14a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.6.4.1",
+        "repo": "agda",
+        "type": "github"
+      }
+    },
+    "agda-stdlib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702291622,
+        "narHash": "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=",
+        "owner": "agda",
+        "repo": "agda-stdlib",
+        "rev": "2b8fff10f4033b91a6df4007e4a65cb10047c89c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v2.0",
+        "repo": "agda-stdlib",
+        "type": "github"
+      }
+    },
+    "agda-tools": {
+      "inputs": {
+        "agda": "agda",
+        "agda-stdlib": "agda-stdlib",
+        "agda2hs": "agda2hs",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "dir": "nix/agda-hs-tools",
+        "lastModified": 1704201306,
+        "narHash": "sha256-U+89uTKTmw2wibbJCSB4yKqEDZzlxYC1xRXbY/31uy0=",
+        "owner": "HeinrichApfelmus",
+        "repo": "agda-notes",
+        "rev": "de15eedb6a3be79dd4a5deee298eb8184bca56af",
+        "type": "github"
+      },
+      "original": {
+        "dir": "nix/agda-hs-tools",
+        "owner": "HeinrichApfelmus",
+        "repo": "agda-notes",
+        "type": "github"
+      }
+    },
+    "agda2hs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702307276,
+        "narHash": "sha256-19NGyK7qbsQ+EBX6lygNFOXRyDm/48KlBf8ixBU7PUw=",
+        "owner": "agda",
+        "repo": "agda2hs",
+        "rev": "b269164e15da03b74cf43b51c522f4f052b4af80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "agda",
+        "ref": "v1.2",
+        "repo": "agda2hs",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -118,8 +199,42 @@
       }
     },
     "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1681378341,
@@ -436,7 +551,7 @@
     "iohkNix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -490,7 +605,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -527,16 +642,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1702913911,
+        "narHash": "sha256-cvn5S6mYynGZV4qTLNJWHIR9pfBQGaiqintt3jiBfdU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "552363205713fb589dde224a9e6f833a369c5bba",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -687,6 +801,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1684171562,
         "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
         "owner": "nixos",
@@ -720,7 +850,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "agda-tools": "agda-tools",
+        "flake-utils": "flake-utils_3",
         "haskellNix": "haskellNix",
         "hls": "hls",
         "iohkNix": "iohkNix",
@@ -781,6 +912,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
       url = "github:cardano-scaling/haskell-language-server?ref=2.6-patched";
       flake = false;
     };
+    agda-tools.url = "github:HeinrichApfelmus/agda-notes?dir=nix/agda-hs-tools";
   };
 
   outputs = inputs:
@@ -52,13 +53,21 @@
             gitAndTools.git
             haskellPackages.ghcid
             haskellPackages.hlint
-
             (haskell-nix.tool "ghc964" "haskell-language-server" ({pkgs, ...}: rec {
-            # Use the github source of HLS that is tested with haskell.nix CI
-            src = inputs.hls;
+              # Use the github source of HLS that is tested with haskell.nix CI
+              src = inputs.hls;
             }))
+
+            inputs.agda-tools.packages.${system}.agda
+            inputs.agda-tools.packages.${system}.agda2hs
           ];
+
+          shell.shellHook = ''
+            export AGDA_DIR=${inputs.agda-tools.packages.${system}.agda-dir.outPath}
+          '';
+
           shell.withHoogle = true;
+
         }).flake (
           # we also want cross compilation to windows.
           nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {


### PR DESCRIPTION
This pull requests add the `Agda` compiler and `agda2hs` transpiler to the `nix develop` shell.

### Issue number

ADP-3191